### PR TITLE
database passwordの修正

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -85,4 +85,4 @@ production:
   host: <%= ENV["RENDER_DB_HOSTNAME"] %>
   database: picnic_db_u07t
   username: picnic_db_u07t_user
-  password: <%= ENV["MYAPP_DATABASE_PASSWORD"] %>
+  password: <%= ENV["RENDER_DB_PASSWORD"] %>


### PR DESCRIPTION
3回目のデプロイ実行。
database.ymlのpasswordの修正が実行できていなかったので、`password: <%= ENV["RENDER_DB_PASSWORD"] %>`に変更し、再度デプロイを実行。