### PR TITLE
レスポンシブ対応

### DIFF
--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -1,3 +1,7 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+html, body {
+  overflow-x: hidden;
+}

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -12,8 +12,10 @@
 
   <body class="flex flex-col min-h-screen bg-accent">
     <%= render 'shared/header' %>
-    <div class="flex-grow container mx-auto px-5 py-8">
-      <%= yield %>
+    <div class="flex-grow">
+      <main class="flex-grow container mx-auto px-5 py-8">
+        <%= yield %>
+      </main>
     </div>
     <%= render 'shared/footer' %>
   </body>

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -1,17 +1,17 @@
-<footer class="footer p-5 bg-lime-800 text-neutral-content">
-  <nav>
+<footer class="flex w-full footer p-3 bg-lime-800 text-neutral-content">
+  <nav class="p-3">
     <h6 class="footer-title text-slate-100">Services</h6> 
     <%= link_to 'ランダム選定', '#', class: "link link-hover text-slate-100" %>
     <%= link_to '公園検索', '#', class: "link link-hover text-slate-100" %>
     <%= link_to '新規投稿', '#', class: "link link-hover text-slate-100" %>
   </nav> 
-  <nav>
+  <nav class="p-3">
     <h6 class="footer-title text-slate-100">Personal</h6> 
     <%= link_to 'ユーザー登録', '#', class: "link link-hover text-slate-100" %>
-    <%= link_to 'プロフィール編集', '#', class: "link link-hover text-slate-100" %>
+    <%= link_to 'マイページ', '#', class: "link link-hover text-slate-100" %>
     <%= link_to 'ログイン', '#', class: "link link-hover text-slate-100" %>
   </nav> 
-  <nav>
+  <nav class="p-3">
     <h6 class="footer-title text-slate-100">Legal</h6> 
     <%= link_to '利用規約', '#', class: "link link-hover text-slate-100" %>
     <%= link_to 'プライバシーポリシー', '#', class: "link link-hover text-slate-100" %>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -1,6 +1,6 @@
 <header class="w-full navbar bg-base-100">
   <div class="flex justify-between items-center w-full">
-    <div class="flex-1 px-2 lg:flex-none">
+    <div class="flex-1 px-2">
       <%= link_to root_path do %>
         <%= image_tag 'logo.png', size: "120x120" %>
       <% end %>

--- a/app/views/tops/index.html.erb
+++ b/app/views/tops/index.html.erb
@@ -1,4 +1,4 @@
-<div class="text-7xl text-park text-center font-bold">Tokyo×Picnic</div>
+<div class="text-4xl md:text-7xl text-park text-center font-bold">Tokyo×Picnic</div>
 
 <div class="py-8">
   <input type="file" class="file-input file-input-bordered file-input-primary w-full max-w-xs" />


### PR DESCRIPTION
・**tailwindcssのレスポンシブ対応について調べ、トップページのレイアウトを変更しました。**
`<div class="text-7xl text-park text-center font-bold">Tokyo×Picnic</div>`となっていたところを
`<div class="text-4xl md:text-7xl text-park text-center font-bold">Tokyo×Picnic</div>`に変更することで、画面サイズに応じて**Tokyo×Picnic**の大きさが変化するようになりました。

・**検証ページで確認した際の、iphone画面の余白を修正しました。**
app/assets/stylesheets/application.tailwind.cssに横スクロールを禁止するcssを設定しました。

・**画面を大きくした際にヘッダーにあるSearchリンクが、中央に移動する状態を解消しました。**
views/shared/_header.html.erbの`lg:flex-none`を削除しました。

Closes #10