### PR TITLE
tailwindconfigの修正

### DIFF
--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -21,7 +21,6 @@ module.exports = {
     },
   },
   plugins: [
-    require('@tailwindcss/forms'),
     require("daisyui")
   ],
   daisyui: {


### PR DESCRIPTION
issue#8のdeviseインストール後、デプロイ失敗により以下のファイルを修正
・tailwind.config.js
render.comのデプロイerrrorで`Error: Cannot find module '@tailwindcss/forms'`と表示された。
使用していない、不要ファイルのため削除しました。