### PR TITLE
ログイン前後でのヘッダーの切り替え

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -11,7 +11,11 @@
   </head>
 
   <body class="flex flex-col min-h-screen bg-accent">
-    <%= render 'shared/header' %>
+    <% if user_signed_in? %>
+      <%= render 'shared/header' %>
+    <% else %>
+      <%= render 'shared/before_login_header' %>
+    <% end %>
     <div class="px-3 pt-1">
       <%= render 'shared/flash_message' %>
     </div>

--- a/app/views/shared/_before_login_header.html.erb
+++ b/app/views/shared/_before_login_header.html.erb
@@ -21,10 +21,10 @@
             <%= link_to 'プロフィール編集', '#', class: "text-park font-semibold hover:bg-slate-200 rounded-lg px-4 py-2" %>
           </li>
           <li>
-            <%= link_to '新規登録', '#', class: "text-park font-semibold hover:bg-slate-200 rounded-lg px-4 py-2" %>
+            <%= link_to '新規登録', new_user_registration_path, class: "text-park font-semibold hover:bg-slate-200 rounded-lg px-4 py-2" %>
           </li>
           <li>
-            <%= link_to 'ログイン', '#', class: "text-park font-semibold hover:bg-slate-200 rounded-lg px-4 py-2" %>
+            <%= link_to 'ログイン', new_user_session_path, class: "text-park font-semibold hover:bg-slate-200 rounded-lg px-4 py-2" %>
           </li> 
         </ul>
       </div>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -21,9 +21,6 @@
             <%= link_to 'プロフィール編集', '#', class: "text-park font-semibold hover:bg-slate-200 rounded-lg px-4 py-2" %>
           </li>
           <li>
-            <%= link_to '新規登録', '#', class: "text-park font-semibold hover:bg-slate-200 rounded-lg px-4 py-2" %>
-          </li>
-          <li>
             <%= link_to 'ログアウト', destroy_user_session_path, data: { turbo_method: :delete}, class: "text-park font-semibold hover:bg-slate-200 rounded-lg px-4 py-2" %>
           </li> 
         </ul>

--- a/app/views/users/registrations/new.html.erb
+++ b/app/views/users/registrations/new.html.erb
@@ -2,34 +2,34 @@
   <%= form_with scope: resource, as: resource_name, url: registration_path(resource_name), local: true do |f| %>
     <%= render "devise/shared/error_messages", resource: resource %>
 
-    <label class="block text-2xl font-bold text-center text-park">
+    <div class="block text-2xl font-bold text-center text-park">
       ユーザー登録
-    </label>
+    </div>
 
     <div class="mt-8">
-      <label class="text-park">
+      <div class="text-park">
         名前
-      </label>
+      </div>
       <%= f.text_field :name, autofocus: true, autocomplete: "name", class: "py-3 px-5 mt-1 block w-full placeholder-gray-400 border-2 border-primary rounded-lg" %>
     </div>
 
     <div class="mt-8">
-      <label class="text-park">
+      <div class="text-park">
         メールアドレス
-      </label>
+      </div>
       <%= f.email_field :email, autofocus: true, autocomplete: "email", class: "py-3 px-5 mt-1 block w-full placeholder-gray-400 border-2 border-primary rounded-lg" %>
     </div>
 
     <div class="mt-8">
-      <label class="text-park text-md">
+      <div class="text-park text-md">
         パスワード
-      </label>
+      </div>
       <%= f.password_field :password, autocomplete: "new-password", class: "py-3 px-5 mt-1 block w-full placeholder-gray-400 border-2 border-primary rounded-lg" %>
     </div>
     <div class="mt-8">
-      <label class="text-park text-md">
+      <div class="text-park text-md">
         確認用パスワード
-      </label>
+      </div>
       <%= f.password_field :password_confirmation, autocomplete: "new-password", class: "py-3 px-5 mt-1 block w-full placeholder-gray-400 border-2 border-primary rounded-lg" %>
     </div>
     

--- a/app/views/users/sessions/new.html.erb
+++ b/app/views/users/sessions/new.html.erb
@@ -1,14 +1,14 @@
 <div class="px-10 py-10 sm:mx-40 xl:mx-96">
-  <label class="block text-2xl font-bold text-center text-park">
+  <div class="block text-2xl font-bold text-center text-park">
     ログイン
-  </label>
+  </div>
   <div class="flex flex-col">
       <%= form_with scope: resource, as: resource_name, url: session_path(resource_name), local: true do |f| %>
         <div class="mt-8">
           <%= f.email_field :email, autofocus: true, autocomplete: "email", class: "py-3 px-5 mt-1 block w-full placeholder-gray-400 border-2 border-primary rounded-lg", placeholder: "メールアドレスを入力" %>
         </div>
         <div class="mt-8">
-          <%= f.password_field :password, autocomplete: "password", class: "py-3 px-5 mt-1 block w-full placeholder-gray-400 border-2 border-primary rounded-lg", placeholder: "パスワードを入力" %>
+          <%= f.password_field :password, class: "py-3 px-5 mt-1 block w-full placeholder-gray-400 border-2 border-primary rounded-lg", placeholder: "パスワードを入力" %>
         </div>
         <div class="mt-8">
           <button type="submit" class="btn btn-primary text-park w-full">
@@ -22,7 +22,7 @@
           <%= button_to "Googleアカウントでログインする", omniauth_authorize_path(resource_name, provider), data: { turbo: false } %><br />
         <% end %>
       </div>
-
+      
       <div class="mt-8 text-center text-park">
         <%= link_to 'はじめての方はこちら', new_user_registration_path %>
       </div>


### PR DESCRIPTION
**ログイン前後で表示するヘッダーの切り替えを行いました。**
・ログイン前のヘッダーにおいて
　・_before_login_header.html.erbを適用させました
 　・ログアウトリンクを削除しました
 　・新規登録を押すと、画面遷移するように変更しました
・ログイン後のヘッダーにおいて
　・ 新規登録のリンクを削除する

Closes #61 