### PR TITLE
公園投稿に必要なモデルの作成

### DIFF
--- a/app/models/park.rb
+++ b/app/models/park.rb
@@ -1,0 +1,7 @@
+class Park < ApplicationRecord
+  has_many :park_reports
+  has_many :tokyo_wards, through: :park_tokyo_wards
+  has_many :park_tokyo_wards
+
+  validates :name, presence: true
+end

--- a/app/models/park_report.rb
+++ b/app/models/park_report.rb
@@ -1,0 +1,5 @@
+class ParkReport < ApplicationRecord
+  belongs_to :user
+  belongs_to :park
+  belongs_to :tokyo_ward
+end

--- a/app/models/park_tokyo_ward.rb
+++ b/app/models/park_tokyo_ward.rb
@@ -1,0 +1,4 @@
+class ParkTokyoWard < ApplicationRecord
+  belongs_to :park
+  belongs_to :tokyo_ward
+end

--- a/app/models/tokyo_ward.rb
+++ b/app/models/tokyo_ward.rb
@@ -1,0 +1,5 @@
+class TokyoWard < ApplicationRecord
+  has_many :park_tokyo_wards
+  has_many :parks, through: :park_distincts
+  has_many :park_reports
+end

--- a/db/migrate/20240505141517_create_parks.rb
+++ b/db/migrate/20240505141517_create_parks.rb
@@ -1,0 +1,12 @@
+class CreateParks < ActiveRecord::Migration[7.1]
+  def change
+    create_table :parks do |t|
+      t.string :name,                    null: false
+      t.string :googlemaps_place_id,     null: false
+      t.string :website_url
+
+      t.timestamps
+    end
+    add_index :parks, :googlemaps_place_id, unique: true
+  end
+end

--- a/db/migrate/20240505144509_create_tokyo_wards.rb
+++ b/db/migrate/20240505144509_create_tokyo_wards.rb
@@ -1,0 +1,11 @@
+class CreateTokyoWards < ActiveRecord::Migration[7.1]
+  def change
+    create_table :tokyo_wards do |t|
+      t.string :name,               null: false
+      t.float :latitude,            null: false
+      t.float :longitude,           null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20240505145543_create_park_tokyo_wards.rb
+++ b/db/migrate/20240505145543_create_park_tokyo_wards.rb
@@ -1,0 +1,12 @@
+class CreateParkTokyoWards < ActiveRecord::Migration[7.1]
+  def change
+    create_table :park_tokyo_wards do |t|
+      t.references :park, null: false, foreign_key: true
+      t.references :tokyo_ward, null: false, foreign_key: true
+
+      t.timestamps
+    end
+
+    add_index :park_tokyo_wards, [:park_id, :tokyo_ward_id], unique: true
+  end
+end

--- a/db/migrate/20240505151131_create_park_reports.rb
+++ b/db/migrate/20240505151131_create_park_reports.rb
@@ -1,0 +1,14 @@
+class CreateParkReports < ActiveRecord::Migration[7.1]
+  def change
+    create_table :park_reports do |t|
+      t.references :user, null: false, foreign_key: true
+      t.references :park, null: false, foreign_key: true
+      t.references :tokyo_ward, null: false, foreign_key: true
+
+      t.date :date
+      t.text :comment
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,41 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_05_04_032430) do
+ActiveRecord::Schema[7.1].define(version: 2024_05_05_151131) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "park_reports", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.bigint "park_id", null: false
+    t.bigint "tokyo_ward_id", null: false
+    t.date "date"
+    t.text "comment"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["park_id"], name: "index_park_reports_on_park_id"
+    t.index ["tokyo_ward_id"], name: "index_park_reports_on_tokyo_ward_id"
+    t.index ["user_id"], name: "index_park_reports_on_user_id"
+  end
+
+  create_table "park_tokyo_wards", force: :cascade do |t|
+    t.bigint "park_id", null: false
+    t.bigint "tokyo_ward_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["park_id", "tokyo_ward_id"], name: "index_park_tokyo_wards_on_park_id_and_tokyo_ward_id", unique: true
+    t.index ["park_id"], name: "index_park_tokyo_wards_on_park_id"
+    t.index ["tokyo_ward_id"], name: "index_park_tokyo_wards_on_tokyo_ward_id"
+  end
+
+  create_table "parks", force: :cascade do |t|
+    t.string "name", null: false
+    t.string "googlemaps_place_id", null: false
+    t.string "website_url"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["googlemaps_place_id"], name: "index_parks_on_googlemaps_place_id", unique: true
+  end
 
   create_table "sns_credentials", force: :cascade do |t|
     t.string "provider"
@@ -21,6 +53,14 @@ ActiveRecord::Schema[7.1].define(version: 2024_05_04_032430) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["user_id"], name: "index_sns_credentials_on_user_id"
+  end
+
+  create_table "tokyo_wards", force: :cascade do |t|
+    t.string "name", null: false
+    t.float "latitude", null: false
+    t.float "longitude", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   create_table "users", force: :cascade do |t|
@@ -36,5 +76,10 @@ ActiveRecord::Schema[7.1].define(version: 2024_05_04_032430) do
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
+  add_foreign_key "park_reports", "parks"
+  add_foreign_key "park_reports", "tokyo_wards"
+  add_foreign_key "park_reports", "users"
+  add_foreign_key "park_tokyo_wards", "parks"
+  add_foreign_key "park_tokyo_wards", "tokyo_wards"
   add_foreign_key "sns_credentials", "users"
 end


### PR DESCRIPTION
**公園の新規投稿に必要な、以下のモデルの作成を行いました**
・Parksモデル
・ParkReportsモデル
・TokyoWardsモデル
・ParkTokyoWardsモデル

**各種モデルのアソシエーションも設定しました**

**以下のデータは別途で実装予定**
・ParksモデルとParkReportモデルのimages
・Parksモデルの公園詳細情報各種(boolean型で登録するデータ)、catchphrase

Closes #15 