### PR TITLE
Google embed map apiの導入

### DIFF
--- a/app/views/park_reports/new.html.erb
+++ b/app/views/park_reports/new.html.erb
@@ -1,3 +1,12 @@
 <%= form_with(model: @park_report, local: true) do |f| %>
   <%= f.collection_select :tokyo_ward_id, TokyoWard.all,  :id, :name, {include_blank: "区を選択"}, {class: "select select-primary max-w-xs"} %>
 <% end %>
+
+<iframe
+  width="450"
+  height="250"
+  frameborder="0" style="border:0"
+  referrerpolicy="no-referrer-when-downgrade"
+  src="https://www.google.com/maps/embed/v1/place?key=<%= ENV['GOOGLE_API_KEY'] %>&q=place_id:ChIJx6xXOPKLGGARtPr6qZZ2nHA"
+  allowfullscreen>
+</iframe>


### PR DESCRIPTION
**Google Embed Maps APIの導入を行いました**
[Embed Maps API](https://developers.google.com/maps/documentation/embed/embedding-map?hl=ja#place_id_parameters)

・Google CloudにてAPIキーを取得しました
・.envファイルにキーを追加しました
・embed mapの表示形式には、placeを指定し、クエリにはplace_idの指定をすることで表示されるよう設定しています
・実際に表示されるかどうかを日比谷公園のplace_idを指定することで確認しました

<img width="983" alt="baab1ac16b8510834de862b89a5da445" src="https://github.com/yamazaki-yuri/tokyopicnic/assets/151484437/96cc7642-487f-4303-9f38-89eda47433ca">
Closes #68 