### PR TITLE
新規投稿機能の作成

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -50,6 +50,8 @@ gem "devise", "~> 4.9", ">= 4.9.3"
 gem "omniauth-google-oauth2"
 gem "omniauth-rails_csrf_protection"
 
+gem 'httparty'
+
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   gem "debug", platforms: %i[ mri windows ]
@@ -59,6 +61,7 @@ end
 group :development do
   # Use console on exceptions pages [https://github.com/rails/web-console]
   gem "web-console"
+  gem 'pry-byebug'
 
   # Add speed badges [https://github.com/MiniProfiler/rack-mini-profiler]
   # gem "rack-mini-profiler"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -84,6 +84,7 @@ GEM
     bootsnap (1.18.3)
       msgpack (~> 1.2)
     builder (3.2.4)
+    byebug (11.1.3)
     capybara (3.40.0)
       addressable
       matrix
@@ -93,11 +94,13 @@ GEM
       rack-test (>= 0.6.3)
       regexp_parser (>= 1.5, < 3.0)
       xpath (~> 3.2)
+    coderay (1.1.3)
     concurrent-ruby (1.2.3)
     connection_pool (2.4.1)
     crass (1.0.6)
     cssbundling-rails (1.4.0)
       railties (>= 6.0.0)
+    csv (3.3.0)
     date (3.3.4)
     debug (1.9.2)
       irb (~> 1.10)
@@ -121,6 +124,10 @@ GEM
     globalid (1.2.1)
       activesupport (>= 6.1)
     hashie (5.0.0)
+    httparty (0.22.0)
+      csv
+      mini_mime (>= 1.0.0)
+      multi_xml (>= 0.5.2)
     i18n (1.14.4)
       concurrent-ruby (~> 1.0)
     io-console (0.7.2)
@@ -144,6 +151,7 @@ GEM
       net-smtp
     marcel (1.0.4)
     matrix (0.4.2)
+    method_source (1.1.0)
     mini_mime (1.1.5)
     minitest (5.22.3)
     msgpack (1.7.2)
@@ -198,6 +206,12 @@ GEM
       omniauth (~> 2.0)
     orm_adapter (0.5.0)
     pg (1.5.6)
+    pry (0.14.2)
+      coderay (~> 1.1)
+      method_source (~> 1.0)
+    pry-byebug (3.10.1)
+      byebug (~> 11.0)
+      pry (>= 0.13, < 0.15)
     psych (5.1.2)
       stringio
     public_suffix (5.0.5)
@@ -314,11 +328,13 @@ DEPENDENCIES
   debug
   devise (~> 4.9, >= 4.9.3)
   dotenv-rails
+  httparty
   jbuilder
   jsbundling-rails
   omniauth-google-oauth2
   omniauth-rails_csrf_protection
   pg (~> 1.1)
+  pry-byebug
   puma (>= 5.0)
   rails (~> 7.1.3, >= 7.1.3.2)
   selenium-webdriver

--- a/app/controllers/park_reports_controller.rb
+++ b/app/controllers/park_reports_controller.rb
@@ -1,4 +1,33 @@
 class ParkReportsController < ApplicationController
   def new
+    @park_report = ParkReport.new
+  end
+
+  def create
+    @tokyo_ward = TokyoWard.find(params[:park_report][:tokyo_ward_id])
+    latitude = @tokyo_ward.latitude
+    longitude = @tokyo_ward.longitude
+    location = "#{latitude},#{longitude}"
+
+    query = params[:park_report][:park_name]
+    google_places_service = GooglePlacesService.new
+    response = google_places_service.search(location, query)
+
+    park_info = response['results'].first
+    place_id = park_info['place_id']
+
+    web_response = google_places_service.get_website(place_id)
+    website = web_response['result']['website']
+    
+    @park = Park.find_or_create_by(name: query, googlemaps_place_id: place_id, website_url: website)
+    
+    @park_report = current_user.park_reports.build(report_params)
+    @park_report.save
+  end
+
+  private
+
+  def report_params
+    params.require(:park_report).permit(:tokyo_ward_id, :date, :comment).merge(park_id: @park.id)
   end
 end

--- a/app/controllers/parks_controller.rb
+++ b/app/controllers/parks_controller.rb
@@ -1,0 +1,5 @@
+class ParksController < ApplicationController
+  def show
+    @park = Park.find(params[:id])
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2,6 +2,7 @@ class User < ApplicationRecord
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   has_many :sns_credentials, dependent: :destroy
+  has_many :park_reports
   
   devise :database_authenticatable, :registerable,
         :recoverable, :rememberable, :validatable,

--- a/app/servise/google_places_service.rb
+++ b/app/servise/google_places_service.rb
@@ -1,0 +1,34 @@
+require 'httparty'
+
+class GooglePlacesService
+  include HTTParty
+  base_uri 'https://maps.googleapis.com/maps/api/place'
+
+  def initialize
+    @api_key = ENV['GOOGLE_API_KEY']
+  end
+
+  def search(location, query)
+    options = {
+      query: {
+        location: location,
+        query: query,
+        radius: 5000,
+        key: @api_key,
+        language: 'ja'
+      }
+    }
+    self.class.get("/textsearch/json", options)
+  end
+
+  def get_website(place_id)
+    options = {
+      query: {
+        place_id: place_id,
+        fields: ['website'],
+        key: @api_key
+      }
+    }
+    self.class.get("/details/json", options)
+  end
+end

--- a/app/views/park_reports/new.html.erb
+++ b/app/views/park_reports/new.html.erb
@@ -1,12 +1,31 @@
-<%= form_with(model: @park_report, local: true) do |f| %>
-  <%= f.collection_select :tokyo_ward_id, TokyoWard.all,  :id, :name, {include_blank: "区を選択"}, {class: "select select-primary max-w-xs"} %>
-<% end %>
-
-<iframe
-  width="450"
-  height="250"
-  frameborder="0" style="border:0"
-  referrerpolicy="no-referrer-when-downgrade"
-  src="https://www.google.com/maps/embed/v1/place?key=<%= ENV['GOOGLE_API_KEY'] %>&q=place_id:ChIJx6xXOPKLGGARtPr6qZZ2nHA"
-  allowfullscreen>
-</iframe>
+<div class="sm:mx-40 xl:mx-96 px-5 flex flex-col">
+  <div class="block text-2xl font-bold text-center text-park">
+      新規投稿
+  </div>
+  <div class="card bg-base-100 shadow-xl mt-8 flex flex-col w-full">
+    <figure class="flex flex-col w-full">
+      <%= form_with(model: @park_report, url: park_reports_path, local: true) do |f| %>
+          <div class="mt-8 flex flex-col w-full">
+            <%= f.label :公園の名前 %>
+            <%= f.text_field :park_name, placeholder: 'Enter a park name', class: "input input-bordered input-primary w-full max-w-xs" %>
+          </div>
+          <div class="mt-8 flex flex-col w-full">
+            <%= f.collection_select :tokyo_ward_id, TokyoWard.all,  :id, :name, {include_blank: "区を選択"}, {class: "select select-primary max-w-xs"} %>
+          </div>
+          <div class="my-5 flex flex-col w-full">
+            <%= f.label :日付 %>
+            <%= f.date_field :date, class: "block shadow rounded-md border border-gray-200 outline-none px-3 py-2 mt-2 w-full" %>
+          </div>
+          <div class="mt-8 mb-8 flex flex-col w-full">
+            <%= f.label :ひとこと %>
+            <%= f.text_field :comment, placeholder: 'コメントを記入', class: "textarea textarea-primary" %>
+          </div>
+    </figure>
+  </div>
+  <div class="mt-8 mx-auto">
+    <button class="btn btn-primary">
+      <%= f.submit '投稿する' %>
+    </button>
+      <% end %>
+  </div>
+</div>

--- a/app/views/parks/show.html.erb
+++ b/app/views/parks/show.html.erb
@@ -1,0 +1,12 @@
+<iframe
+  width="450"
+  height="250"
+  frameborder="0" style="border:0"
+  referrerpolicy="no-referrer-when-downgrade"
+  src="https://www.google.com/maps/embed/v1/place?key=<%= ENV['GOOGLE_API_KEY'] %>&q=place_id:<%= @park.googlemaps_place_id %>"
+  allowfullscreen>
+</iframe>
+
+<div>
+  <%= link_to '公式サイト', "#{@park.website_url}" %>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,7 +3,8 @@ Rails.application.routes.draw do
     sessions: 'users/sessions',
     omniauth_callbacks: 'users/omniauth_callbacks'
   }
-  resources :park_reports, only: [:new]
+  resources :park_reports, only: [:new, :create]
+  resources :parks, only: [:show]
   
   root 'tops#index'
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html


### PR DESCRIPTION
・**以下のGemをインストールしました**
　・gem 'httparty'
　・gem 'pry-byebug'
・**Park_reportの新規作成を実装しました。新規投稿の流れは以下の通りです**
1. park_reports/newにて、ユーザーが公園名を自由記入、23区をタブ選択、行った日付を選択、コメントを記入する
2. 入力された公園名と区のクエリを元にGoogle Place APIのテキスト検索にて、該当の公園のplace_idを取得(区のクエリは、検索範囲の絞り込みに使用)
3. 取得したplace_idを元に、Google Place APIのPlace Detailsにリクエストを飛ばし、websiteのurlを取得
4. 入力された`park_name`・取得した`place_id`と`websiteのurl`はParkモデルに保存
5. 記入したユーザーによる公園のレポートとして、`tokyo_ward_id`・`date`・`comment`・`park_id`をParkReportsモデルに保存

・**views/parks/show.html.erbを作成し、保存された内容を確認しました**
取得したplace_idを、Google Embed Map APIのクエリに組み込み、公園詳細としてmapを表示させました。
取得したwebsite_urlから公式サイトへ飛べるかどうか確認しました。
![ecb60e7bd11649d282b1b47208a88c09](https://github.com/yamazaki-yuri/tokyopicnic/assets/151484437/9225fa85-ad09-473e-b3ca-602a6892388e)

<img width="936" alt="e3af44825874b2115713822d101be97f" src="https://github.com/yamazaki-yuri/tokyopicnic/assets/151484437/4e8f3ee0-f5b3-4476-b2e8-a5cbf749aa0f">

Closes #16 
