### PR TITLE
park_report作成時の条件分岐を追加

### DIFF
--- a/app/controllers/park_reports_controller.rb
+++ b/app/controllers/park_reports_controller.rb
@@ -4,14 +4,50 @@ class ParkReportsController < ApplicationController
   end
 
   def create
-    @tokyo_ward = TokyoWard.find(params[:park_report][:tokyo_ward_id])
+    @park_name = params[:park_report][:park_name]
+    @park = Park.find_by(name: @park_name)
+
+    if @park
+      @tokyo_ward = @park.tokyo_wards.first
+    else
+      if params[:park_report][:tokyo_ward_id].present?
+        @tokyo_ward = TokyoWard.find(params[:park_report][:tokyo_ward_id])
+      else
+        flash[:danger] = "区を選択してください"
+        render :new, status: :unprocessable_entity
+        return
+      end
+
+      create_park_and_associate_tokyo_ward
+    end
+
+    save_park_report
+  end
+
+  private
+
+  def report_params
+    params.require(:park_report).permit(:date, :comment).merge(park_id: @park.id, tokyo_ward_id: @tokyo_ward.id)
+  end
+
+  def save_park_report
+    @park_report = current_user.park_reports.build(report_params)
+    if @park_report.save
+      flash[:success] = "投稿しました"
+      redirect_to park_path(@park)
+    else
+      flash[:danger] = "投稿に失敗しました"
+      render :new, status: :unprocessable_entity
+    end
+  end
+
+  def create_park_and_associate_tokyo_ward
     latitude = @tokyo_ward.latitude
     longitude = @tokyo_ward.longitude
     location = "#{latitude},#{longitude}"
 
-    query = params[:park_report][:park_name]
     google_places_service = GooglePlacesService.new
-    response = google_places_service.search(location, query)
+    response = google_places_service.search(location, @park_name)
 
     park_info = response['results'].first
     place_id = park_info['place_id']
@@ -19,15 +55,7 @@ class ParkReportsController < ApplicationController
     web_response = google_places_service.get_website(place_id)
     website = web_response['result']['website']
     
-    @park = Park.find_or_create_by(name: query, googlemaps_place_id: place_id, website_url: website)
-    
-    @park_report = current_user.park_reports.build(report_params)
-    @park_report.save
-  end
-
-  private
-
-  def report_params
-    params.require(:park_report).permit(:tokyo_ward_id, :date, :comment).merge(park_id: @park.id)
+    @park = Park.create(name: @park_name, googlemaps_place_id: place_id, website_url: website)
+    @park.tokyo_wards << @tokyo_ward
   end
 end

--- a/app/models/park.rb
+++ b/app/models/park.rb
@@ -1,7 +1,7 @@
 class Park < ApplicationRecord
   has_many :park_reports
-  has_many :tokyo_wards, through: :park_tokyo_wards
   has_many :park_tokyo_wards
+  has_many :tokyo_wards, through: :park_tokyo_wards
 
   validates :name, presence: true
 end

--- a/app/models/tokyo_ward.rb
+++ b/app/models/tokyo_ward.rb
@@ -1,5 +1,5 @@
 class TokyoWard < ApplicationRecord
   has_many :park_tokyo_wards
-  has_many :parks, through: :park_distincts
   has_many :park_reports
+  has_many :parks, through: :park_tokyo_wards
 end

--- a/app/views/park_reports/new.html.erb
+++ b/app/views/park_reports/new.html.erb
@@ -6,28 +6,27 @@
   <div class="card bg-base-100 shadow-xl mt-8 flex flex-col w-full">
     <figure class="flex flex-col w-full">
       <%= form_with(model: @park_report, url: park_reports_path, local: true) do |f| %>
-        <%= render 'shared/error_messages', object: @park_report %>
-          <div class="mt-8 flex flex-col w-full">
-            <%= f.label :name, "公園の名前" %>
-            <%= f.text_field :park_name, placeholder: 'Enter a park name', class: "input input-bordered input-primary w-full max-w-xs" %>
-          </div>
-          <div class="mt-8 flex flex-col w-full">
-            <%= f.collection_select :tokyo_ward_id, TokyoWard.all,  :id, :name, {include_blank: "区を選択"}, {class: "select select-primary max-w-xs"} %>
-          </div>
-          <div class="my-5 flex flex-col w-full">
-            <%= f.label :date, "日付(任意)" %>
-            <%= f.date_field :date, class: "block shadow rounded-md border border-gray-200 outline-none px-3 py-2 mt-2 w-full" %>
-          </div>
-          <div class="mt-8 mb-8 flex flex-col w-full">
-            <%= f.label :comment, "ひとこと" %>
-            <%= f.text_field :comment, placeholder: 'コメントを記入', class: "textarea textarea-primary" %>
-          </div>
-    </figure>
-  </div>
-  <div class="mt-8 mx-auto">
-    <button class="btn btn-primary">
-      <%= f.submit '投稿する' %>
-    </button>
+        <div class="mt-8 flex flex-col w-full">
+          <%= f.label :name, "公園の名前" %>
+          <%= f.text_field :park_name, placeholder: '公園の名前を入れてね', class: "input input-bordered input-primary w-full max-w-xs" %>
+        </div>
+        <div class="mt-8 flex flex-col w-2/3">
+          <%= f.collection_select :tokyo_ward_id, TokyoWard.all,  :id, :name, {include_blank: "区を選択"}, {class: "select select-primary max-w-xs"} %>
+        </div>
+        <div class="my-5 flex flex-col w-full">
+          <%= f.label :date, "日付(任意)" %>
+          <%= f.date_field :date, class: "block shadow rounded-md border border-gray-200 outline-none px-3 py-2 mt-2 w-full" %>
+        </div>
+        <div class="mt-8 mb-8 flex flex-col w-full">
+          <%= f.label :comment, "ひとこと" %>
+          <%= f.text_field :comment, placeholder: '思ったことを自由に記入', class: "textarea textarea-primary" %>
+        </div>
+        <div class="my-5 flex flex-col w-full">
+          <button class="btn btn-primary">
+            <%= f.submit '投稿する' %>
+          </button>
+        </div>
       <% end %>
+    </figure>
   </div>
 </div>

--- a/app/views/shared/_error_messages.html.erb
+++ b/app/views/shared/_error_messages.html.erb
@@ -1,5 +1,5 @@
 <% if object.errors.any? %>
-  <div role="alert" class="alert alert-error">
+  <div role="alert" class="alert bg-primary border-none text-park font-semibold shadow-lg mt-5">
     <ul class="mb-0">
       <% object.errors.full_messages.each do |msg| %>
         <li><%= msg %></li>


### PR DESCRIPTION
**park_reportsを新規作成するときにの条件分岐を追加しました。**
既存の実装では、新規投稿の際は`公園の入力`と`区の選択`は必須でした。
今回の実装で、入力された公園の名前がParkモデルにすでに存在する場合と、そうでない場合で条件を分岐しました。
また、この条件分岐の実現のため、新たな公園が追加される時に、ParkTokyoWardsモデルも更新されるよう修正しました。
1. Parkモデルにすでに存在する公園が入力された時
**区を選択しなくても投稿できる**
![aa41c4b66701e04aad0f678f6ed5817c](https://github.com/yamazaki-yuri/tokyopicnic/assets/151484437/a4256cae-1e7f-4797-9cfb-315c49027460)

**代々木公園(渋谷区)で登録してあるが、代々木公園(新宿区)で投稿したとき**
既存の代々木公園の区の情報が取得され、代々木公園(新宿区)は作成されない。
(どちらも`http://localhost:3000/parks/11`にリダイレクトできている。)
![7bf30c31ad7e415d362ffeaffb57f21e](https://github.com/yamazaki-yuri/tokyopicnic/assets/151484437/0cbb0a4f-b972-4371-856e-a8ebe2d63ed1)
![ec75b61a39cf04fa558b03621718b1db](https://github.com/yamazaki-yuri/tokyopicnic/assets/151484437/3befb852-a1e3-46de-9dc9-18dd489aa6ed)

2. Parkモデルにない公園が入力された時
**区の選択があれば、今まで通り投稿できる**
![c5fc41f6b5d6dba34178e7a803b4be50](https://github.com/yamazaki-yuri/tokyopicnic/assets/151484437/910bbdf5-22f5-45b6-87ea-7c4ce453baaf)

**区の選択がない時は、"区を選択してください"というフラッシュメッセージが出る**
![844c08c4051e4f08a72bea85cbbc0d12](https://github.com/yamazaki-yuri/tokyopicnic/assets/151484437/5ce93066-6aea-496e-a5fb-0836780986f3)

Closes #76 