### PR TITLE
ログイン前に新規投稿ページに遷移できないよう修正

### DIFF
--- a/app/controllers/park_reports_controller.rb
+++ b/app/controllers/park_reports_controller.rb
@@ -1,4 +1,6 @@
 class ParkReportsController < ApplicationController
+  before_action :authenticate_user!
+  
   def new
     @park_report = ParkReport.new
   end


### PR DESCRIPTION
ログイン前のユーザーが新規投稿ページに遷移できなくなるよう修正しました。
・park_reports_controller.rbに`before_action :authenticate_user!`を追記しました

![50ad228af267a5afa44315779b2b8e27](https://github.com/yamazaki-yuri/tokyopicnic/assets/151484437/855c0280-a6fa-4b00-bac1-7261715de7bc)
