### PR TITLE
Feature report images

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@
 !/tmp/storage/.keep
 
 /public/assets
+/public
 
 # Ignore master key for decrypting credentials and more.
 /config/master.key

--- a/Gemfile
+++ b/Gemfile
@@ -53,6 +53,9 @@ gem "omniauth-rails_csrf_protection"
 
 gem 'httparty'
 
+gem 'carrierwave', '~> 3.0'
+gem 'mini_magick'
+
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   gem "debug", platforms: %i[ mri windows ]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -94,6 +94,13 @@ GEM
       rack-test (>= 0.6.3)
       regexp_parser (>= 1.5, < 3.0)
       xpath (~> 3.2)
+    carrierwave (3.0.7)
+      activemodel (>= 6.0.0)
+      activesupport (>= 6.0.0)
+      addressable (~> 2.6)
+      image_processing (~> 1.1)
+      marcel (~> 1.0.0)
+      ssrf_filter (~> 1.0)
     coderay (1.1.3)
     concurrent-ruby (1.2.3)
     connection_pool (2.4.1)
@@ -123,6 +130,7 @@ GEM
       faraday-net_http (>= 2.0, < 3.2)
     faraday-net_http (3.1.0)
       net-http
+    ffi (1.16.3)
     globalid (1.2.1)
       activesupport (>= 6.1)
     hashie (5.0.0)
@@ -132,6 +140,9 @@ GEM
       multi_xml (>= 0.5.2)
     i18n (1.14.4)
       concurrent-ruby (~> 1.0)
+    image_processing (1.12.2)
+      mini_magick (>= 4.9.5, < 5)
+      ruby-vips (>= 2.0.17, < 3)
     io-console (0.7.2)
     irb (1.12.0)
       rdoc
@@ -154,6 +165,7 @@ GEM
     marcel (1.0.4)
     matrix (0.4.2)
     method_source (1.1.0)
+    mini_magick (4.12.0)
     mini_mime (1.1.5)
     minitest (5.22.3)
     msgpack (1.7.2)
@@ -270,6 +282,8 @@ GEM
       actionpack (>= 5.2)
       railties (>= 5.2)
     rexml (3.2.6)
+    ruby-vips (2.2.1)
+      ffi (~> 1.12)
     rubyzip (2.3.2)
     selenium-webdriver (4.20.1)
       base64 (~> 0.2)
@@ -286,6 +300,7 @@ GEM
       actionpack (>= 5.2)
       activesupport (>= 5.2)
       sprockets (>= 3.0.0)
+    ssrf_filter (1.1.2)
     stimulus-rails (1.3.3)
       railties (>= 6.0.0)
     stringio (3.1.0)
@@ -326,6 +341,7 @@ PLATFORMS
 DEPENDENCIES
   bootsnap
   capybara
+  carrierwave (~> 3.0)
   cssbundling-rails
   debug
   devise (~> 4.9, >= 4.9.3)
@@ -334,6 +350,7 @@ DEPENDENCIES
   httparty
   jbuilder
   jsbundling-rails
+  mini_magick
   omniauth-google-oauth2
   omniauth-rails_csrf_protection
   pg (~> 1.1)

--- a/app/controllers/park_reports_controller.rb
+++ b/app/controllers/park_reports_controller.rb
@@ -3,6 +3,7 @@ class ParkReportsController < ApplicationController
   
   def new
     @park_report = ParkReport.new
+    2.times { @park_report.report_images.build }
   end
 
   def create
@@ -29,7 +30,7 @@ class ParkReportsController < ApplicationController
   private
 
   def report_params
-    params.require(:park_report).permit(:date, :comment).merge(park_id: @park.id, tokyo_ward_id: @tokyo_ward.id)
+    params.require(:park_report).permit(:date, :comment, report_images_attributes: [:url]).merge(park_id: @park.id, tokyo_ward_id: @tokyo_ward.id)
   end
 
   def save_park_report

--- a/app/controllers/park_reports_controller.rb
+++ b/app/controllers/park_reports_controller.rb
@@ -27,6 +27,11 @@ class ParkReportsController < ApplicationController
     save_park_report
   end
 
+  def show
+    @park_report = ParkReport.find(params[:id])
+    @report_images = @park_report.report_images
+  end
+
   private
 
   def report_params

--- a/app/models/park_report.rb
+++ b/app/models/park_report.rb
@@ -2,4 +2,6 @@ class ParkReport < ApplicationRecord
   belongs_to :user
   belongs_to :park
   belongs_to :tokyo_ward
+  has_many :report_images
+  accepts_nested_attributes_for :report_images
 end

--- a/app/models/report_image.rb
+++ b/app/models/report_image.rb
@@ -1,0 +1,4 @@
+class ReportImage < ApplicationRecord
+  belongs_to :park_report
+  mount_uploader :url, ReportImageUploader
+end

--- a/app/uploaders/report_image_uploader.rb
+++ b/app/uploaders/report_image_uploader.rb
@@ -1,0 +1,47 @@
+class ReportImageUploader < CarrierWave::Uploader::Base
+  # Include RMagick or MiniMagick support:
+  # include CarrierWave::RMagick
+  # include CarrierWave::MiniMagick
+
+  # Choose what kind of storage to use for this uploader:
+  storage :file
+  # storage :fog
+
+  # Override the directory where uploaded files will be stored.
+  # This is a sensible default for uploaders that are meant to be mounted:
+  def store_dir
+    "uploads/#{model.class.to_s.underscore}/#{mounted_as}/#{model.id}"
+  end
+
+  # Provide a default URL as a default if there hasn't been a file uploaded:
+  # def default_url(*args)
+  #   # For Rails 3.1+ asset pipeline compatibility:
+  #   # ActionController::Base.helpers.asset_path("fallback/" + [version_name, "default.png"].compact.join('_'))
+  #
+  #   "/images/fallback/" + [version_name, "default.png"].compact.join('_')
+  # end
+
+  # Process files as they are uploaded:
+  # process scale: [200, 300]
+  #
+  # def scale(width, height)
+  #   # do something
+  # end
+
+  # Create different versions of your uploaded files:
+  # version :thumb do
+  #   process resize_to_fit: [50, 50]
+  # end
+
+  # Add an allowlist of extensions which are allowed to be uploaded.
+  # For images you might use something like this:
+  # def extension_allowlist
+  #   %w(jpg jpeg gif png)
+  # end
+
+  # Override the filename of the uploaded files:
+  # Avoid using model.id or version_name here, see uploader/store.rb for details.
+  # def filename
+  #   "something.jpg"
+  # end
+end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -19,7 +19,7 @@
     <div class="px-3 pt-1">
       <%= render 'shared/flash_message' %>
     </div>
-    <div class="flex-grow container mx-auto px-5 py-10">
+    <div class="flex-grow container mx-auto px-6 py-10">
       <%= yield %>
     </div>
     <%= render 'shared/footer' %>

--- a/app/views/park_reports/new.html.erb
+++ b/app/views/park_reports/new.html.erb
@@ -1,27 +1,33 @@
 <% content_for(:title, t('.title')) %>
-<div class="sm:mx-40 xl:mx-96 px-5 flex flex-col">
-  <div class="block text-2xl font-bold text-center text-park">
-      新規投稿
-  </div>
-  <div class="card bg-base-100 shadow-xl mt-8 flex flex-col w-full">
-    <figure class="flex flex-col w-full">
+<div class="block text-2xl font-bold text-center text-park">
+    新規投稿
+</div>
+<div class="flex justify-center items-center">
+  <div class="card bg-base-100 shadow-xl mt-8 flex flex-col w-96">
+    <figure class="flex">
       <%= form_with(model: @park_report, url: park_reports_path, local: true) do |f| %>
-        <div class="mt-8 flex flex-col w-full">
+        <div class="mt-8 flex flex-col px-5">
           <%= f.label :name, "公園の名前" %>
           <%= f.text_field :park_name, placeholder: '公園の名前を入れてね', class: "input input-bordered input-primary w-full max-w-xs" %>
         </div>
-        <div class="mt-8 flex flex-col w-2/3">
+        <div class="mt-8 flex flex-col w-2/3 px-5">
           <%= f.collection_select :tokyo_ward_id, TokyoWard.all,  :id, :name, {include_blank: "区を選択"}, {class: "select select-primary max-w-xs"} %>
         </div>
-        <div class="my-5 flex flex-col w-full">
+        <div class="my-5 flex flex-col px-5">
           <%= f.label :date, "日付(任意)" %>
           <%= f.date_field :date, class: "block shadow rounded-md border border-gray-200 outline-none px-3 py-2 mt-2 w-full" %>
         </div>
-        <div class="mt-8 mb-8 flex flex-col w-full">
+          <%= f.fields_for :report_images do |report_image| %>
+            <div class="field mt-8 flex flex-col pl-5">
+              <%= report_image.label :url, "写真" %>
+              <%= report_image.file_field :url %>
+            </div>
+          <% end %>
+        <div class="mt-8 mb-8 flex flex-col px-5">
           <%= f.label :comment, "ひとこと" %>
           <%= f.text_field :comment, placeholder: '思ったことを自由に記入', class: "textarea textarea-primary" %>
         </div>
-        <div class="my-5 flex flex-col w-full">
+        <div class="my-5 flex flex-col px-5">
           <button class="btn btn-primary">
             <%= f.submit '投稿する' %>
           </button>
@@ -30,3 +36,4 @@
     </figure>
   </div>
 </div>
+

--- a/app/views/park_reports/show.html.erb
+++ b/app/views/park_reports/show.html.erb
@@ -1,0 +1,6 @@
+<div>
+  <% @report_images.each do |report_image| %>
+    <%= image_tag report_image.url.url, size: "250x250"%>
+  <% end %>
+</div>
+<%= @park_report.comment %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,7 +3,7 @@ Rails.application.routes.draw do
     sessions: 'users/sessions',
     omniauth_callbacks: 'users/omniauth_callbacks'
   }
-  resources :park_reports, only: [:new, :create]
+  resources :park_reports, only: [:new, :create, :show]
   resources :parks, only: [:show]
   
   root 'tops#index'

--- a/db/migrate/20240511025320_create_report_images.rb
+++ b/db/migrate/20240511025320_create_report_images.rb
@@ -1,0 +1,10 @@
+class CreateReportImages < ActiveRecord::Migration[7.1]
+  def change
+    create_table :report_images do |t|
+      t.references :park_report, null: false, foreign_key: true
+      t.string :url
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_05_05_151131) do
+ActiveRecord::Schema[7.1].define(version: 2024_05_11_025320) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -44,6 +44,14 @@ ActiveRecord::Schema[7.1].define(version: 2024_05_05_151131) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["googlemaps_place_id"], name: "index_parks_on_googlemaps_place_id", unique: true
+  end
+
+  create_table "report_images", force: :cascade do |t|
+    t.bigint "park_report_id", null: false
+    t.string "url"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["park_report_id"], name: "index_report_images_on_park_report_id"
   end
 
   create_table "sns_credentials", force: :cascade do |t|
@@ -81,5 +89,6 @@ ActiveRecord::Schema[7.1].define(version: 2024_05_05_151131) do
   add_foreign_key "park_reports", "users"
   add_foreign_key "park_tokyo_wards", "parks"
   add_foreign_key "park_tokyo_wards", "tokyo_wards"
+  add_foreign_key "report_images", "park_reports"
   add_foreign_key "sns_credentials", "users"
 end


### PR DESCRIPTION
ParkRepors作成時の画像のアップロード機能を実装しました。
**下記のgemをインストールしました。**
・gem 'carrierwave', '~> 3.0'
**下記のファイルを作成しました。**
・ReportImagesモデル
・ReportImageUploader
Park_reports/newで画像投稿機能を実装し、park_reports詳細ページで画像の確認を行いました。
現状、ファイル形式の設定ができておらず、heic形式のファイルがアップロードできない状況です。


<img width="820" alt="c90c981bfa61e4ee6cc6359eb32e7171" src="https://github.com/yamazaki-yuri/tokyopicnic/assets/151484437/71d9830d-7964-40cb-89d3-117a13fb1756">

<img width="834" alt="343eea4bf448e818dfa1881bd174a501" src="https://github.com/yamazaki-yuri/tokyopicnic/assets/151484437/b1876423-00d8-4094-9935-e7bfa3b68347">

Closes #24 