### PR TITLE
公園の画像を登録できるようにする

### DIFF
--- a/app/controllers/park_images_controller.rb
+++ b/app/controllers/park_images_controller.rb
@@ -1,0 +1,20 @@
+class ParkImagesController < ApplicationController
+  def create
+    @park = Park.find(params[:park_image][:park_id])
+    @park_image = @park.park_images.build(park_image_params)
+
+    if @park_image.save
+      flash[:success] = "画像を投稿しました"
+      redirect_to @park
+    else
+      flash[:danger] = "投稿に失敗しました"
+      render 'parks/show', status: :unprocessable_entity
+    end
+  end
+
+  private
+
+  def park_image_params
+    params.require(:park_image).permit(:url).merge(park_id: @park.id)
+  end
+end

--- a/app/controllers/parks_controller.rb
+++ b/app/controllers/parks_controller.rb
@@ -1,5 +1,7 @@
 class ParksController < ApplicationController
   def show
     @park = Park.find(params[:id])
+    @park_image = ParkImage.new
+    @park_images = @park.park_images
   end
 end

--- a/app/models/park.rb
+++ b/app/models/park.rb
@@ -2,6 +2,7 @@ class Park < ApplicationRecord
   has_many :park_reports
   has_many :park_tokyo_wards
   has_many :tokyo_wards, through: :park_tokyo_wards
+  has_many :park_images
 
   validates :name, presence: true
 end

--- a/app/models/park_image.rb
+++ b/app/models/park_image.rb
@@ -1,0 +1,4 @@
+class ParkImage < ApplicationRecord
+  belongs_to :park
+  mount_uploader :url, ParkImageUploader
+end

--- a/app/uploaders/park_image_uploader.rb
+++ b/app/uploaders/park_image_uploader.rb
@@ -1,0 +1,32 @@
+class ParkImageUploader < CarrierWave::Uploader::Base
+  # Include RMagick or MiniMagick support:
+  # include CarrierWave::RMagick
+  include CarrierWave::MiniMagick
+
+  # Choose what kind of storage to use for this uploader:
+  storage :file
+  # storage :fog
+
+  # Override the directory where uploaded files will be stored.
+  # This is a sensible default for uploaders that are meant to be mounted:
+  def store_dir
+    "uploads/#{model.class.to_s.underscore}/#{mounted_as}/#{model.id}"
+  end
+
+  def extension_allowlist
+    %w[jpg jpeg png heic webp]
+  end
+
+  process :convert_to_webp
+
+  def convert_to_webp
+    manipulate! do |img|
+      img.format 'webp'
+      img
+    end
+  end
+
+  def filename
+    super.chomp(File.extname(super)) + '.webp' if original_filename.present?
+  end
+end

--- a/app/views/park_images/_form.html.erb
+++ b/app/views/park_images/_form.html.erb
@@ -1,0 +1,9 @@
+<%= form_with(model: @park_image, remote: true, local: true, url: park_images_path, class: "justify-between item-center") do |f| %>
+  <%= f.hidden_field :park_id, value: @park.id %>
+  <div class="field px-2">
+  <%= f.file_field :url, class: "file-input file-input-bordered file-input-accent w-full max-w-xs" %>
+  </div>
+  <div class="btn btn-ghost rounded-btn hover:bg-slate-200 text-park mt-5 w-full">
+    <%= f.submit '投稿する' %>
+  </div>
+<% end %>

--- a/app/views/parks/show.html.erb
+++ b/app/views/parks/show.html.erb
@@ -1,3 +1,9 @@
+<div>
+  <% @park_images.each do |park_image| %>
+    <%= image_tag park_image.url.url, size: "250x250"%>
+  <% end %>
+</div>
+
 <iframe
   width="450"
   height="250"
@@ -10,3 +16,17 @@
 <div>
   <%= link_to '公式サイト', "#{@park.website_url}" %>
 </div>
+
+
+
+<button class="btn" onclick="my_modal_2.showModal()">画像を追加する</button>
+<dialog id="my_modal_2" class="modal">
+  <div class="modal-box">
+    <p class="text-park font-bold pb-5 text-center">画像を追加してね<p>
+    <%= render 'park_images/form', park_image: @park_image %>
+  </div>
+  <form method="dialog" class="modal-backdrop">
+    <button>close</button>
+  </form>
+</dialog>
+

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,6 +5,7 @@ Rails.application.routes.draw do
   }
   resources :park_reports, only: [:new, :create, :show]
   resources :parks, only: [:show]
+  resources :park_images, only: [:new, :create]
   
   root 'tops#index'
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html

--- a/db/migrate/20240511063443_create_park_images.rb
+++ b/db/migrate/20240511063443_create_park_images.rb
@@ -1,0 +1,10 @@
+class CreateParkImages < ActiveRecord::Migration[7.1]
+  def change
+    create_table :park_images do |t|
+      t.references :park, null: false, foreign_key: true
+      t.string :url
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,17 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_05_11_025320) do
+ActiveRecord::Schema[7.1].define(version: 2024_05_11_063443) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "park_images", force: :cascade do |t|
+    t.bigint "park_id", null: false
+    t.string "url"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["park_id"], name: "index_park_images_on_park_id"
+  end
 
   create_table "park_reports", force: :cascade do |t|
     t.bigint "user_id", null: false
@@ -84,6 +92,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_05_11_025320) do
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
+  add_foreign_key "park_images", "parks"
   add_foreign_key "park_reports", "parks"
   add_foreign_key "park_reports", "tokyo_wards"
   add_foreign_key "park_reports", "users"


### PR DESCRIPTION
公園の写真が投稿できるよう実装しました。
写真投稿の流れは以下のとおりです。
1. ユーザーが公園詳細ページ(parks/id)から、"画像を追加する"を押すと、画像投稿フォームのモーダルが開く
2. 画像を選択し"投稿する"を押す
3. 写真の投稿が完了すると"画像を投稿しました"というフラッシュメッセージが表示され、公園詳細ページにリダイレクトする
4. 公園詳細ページに公園の画像が表示される

画像投稿機能の実装に伴い、ParkImagesモデルを新たに作成しました。
![e7cac153b695c40d0e3952980789bd6f](https://github.com/yamazaki-yuri/tokyopicnic/assets/151484437/c89af7c0-e3a2-4753-89af-b91bae2155b8)

Closes #82 