### PR TITLE
公園詳細ページにmapを表示する

### DIFF
--- a/app/views/parks/show.html.erb
+++ b/app/views/parks/show.html.erb
@@ -1,18 +1,13 @@
 <div>
   <% @park_images.each do |park_image| %>
-    <%= image_tag park_image.url.url, size: "250x250"%>
+    <% if park_image.url.present? %>
+      <%= image_tag park_image.url.url, size: "250x250"%>
+    <% end %>
   <% end %>
 </div>
 
-<iframe
-  width="450"
-  height="250"
-  frameborder="0" style="border:0"
-  referrerpolicy="no-referrer-when-downgrade"
-  src="https://www.google.com/maps/embed/v1/place?key=<%= ENV['GOOGLE_API_KEY'] %>&q=place_id:<%= @park.googlemaps_place_id %>"
-  allowfullscreen>
-</iframe>
 
+<%= render 'shared/map' %>
 <div>
   <%= link_to '公式サイト', "#{@park.website_url}" %>
 </div>

--- a/app/views/shared/_map.html.erb
+++ b/app/views/shared/_map.html.erb
@@ -1,0 +1,8 @@
+<iframe
+  width="450"
+  height="250"
+  frameborder="0" style="border:0"
+  referrerpolicy="no-referrer-when-downgrade"
+  src="https://www.google.com/maps/embed/v1/place?key=<%= ENV['GOOGLE_API_KEY'] %>&q=place_id:<%= @park.googlemaps_place_id %>"
+  allowfullscreen>
+</iframe>


### PR DESCRIPTION
公園詳細ページのmapを、shared/_map.html.erbに切り出して表示されるよう変更しました。
画像のurlがnilの時に下記のエラーが発生する状態を改善しました。
<img width="872" alt="f0a40790e3943ee246aaf044e952a58d" src="https://github.com/yamazaki-yuri/tokyopicnic/assets/151484437/c47dd821-aa39-4671-a033-9813b5fc78cf">

Closes #27 