### PR TITLE
投稿詳細ページの表示

### DIFF
--- a/app/controllers/park_reports_controller.rb
+++ b/app/controllers/park_reports_controller.rb
@@ -28,8 +28,7 @@ class ParkReportsController < ApplicationController
   end
 
   def show
-    @park_report = ParkReport.find(params[:id])
-    @report_images = @park_report.report_images
+    @park_report = ParkReport.includes(:report_images, :park).find(params[:id])
   end
 
   private

--- a/app/views/park_reports/show.html.erb
+++ b/app/views/park_reports/show.html.erb
@@ -1,6 +1,36 @@
-<div>
-  <% @report_images.each do |report_image| %>
-    <%= image_tag report_image.url.url, size: "250x250"%>
-  <% end %>
+<div class="flex justify-center items-center md:justify-between flex-col md:flex-row md:gap-x-10">
+  <div class="card bg-base-100 shadow-xl flex flex-col md:flex-row w-full h-auto md:h-full object-cover">
+    <figure class="rounded-md">
+      <div>
+        <%= image_tag @park_report.report_images.first.url.url %>
+      </div>
+    </figure>
+  </div>
+  <div class="card-body bg-white rounded-md w-full h-auto md:h-full object-cover">
+      <h2 class="card-title pb-2 pl-3 border-b-2 border-slate-200 text-park">
+        <%= link_to "#{@park_report.park.name}", "#{park_path(@park_report.park)}" %>
+        <%= link_to '公式サイト', "#{@park_report.park.website_url}", class: "badge badge-secondary border-b-2 border-park text-park" %>
+      </h2>
+      <div class="border-b-2 border-slate-200 pb-1 text-park">
+        <p class="pl-8"><%= @park_report.date %><p>
+      </div>
+      <div class="border-b-2 border-slate-200 pb-1 text-park">
+        <p class="pl-8"><%= @park_report.comment %><p>
+      </div>
+      <div class="border-b-2 border-slate-200 pb-1 text-park">
+        <p class="pl-8">この日は朝からカラオケにいてセカオワのライブの予習をしてた。数年ぶりのカラオケ楽しかった！ライブ前にセカオワファンの集合写真に混ざって写った笑ライブ魔の時間潰しに代々木公園にいったら、人がたくさんいた。<p>
+      </div>
+    </div>
+  </div>
+  <div class="flex justify-center items-center md:justify-between flex-col md:flex-row md:gap-x-5 gap-y-8 py-10 px-8 grid md:grid-cols-4 ">
+    <% @park_report.report_images.each do |report_image| %>
+      <div class="card bg-base-100 shadow-xl flex flex-col md:gap-x-10 rounded-lg" >
+        <figure>
+          <div>
+            <%= image_tag report_image.url.url, class: "w-full h-auto object-cover rounded-lg "%>
+          </div>
+        </figure>
+      </div>
+    <% end %>
+  </div>
 </div>
-<%= @park_report.comment %>

--- a/app/views/parks/show.html.erb
+++ b/app/views/parks/show.html.erb
@@ -1,7 +1,7 @@
 <div class="text-center">
   <p class="text-park">- <%=  @tokyo_ward.name %> -<p>
   <div class="flex justify-center items-center">
-    <p class="text-park text-3xl md:text-4xl py-3 border-b-2 border-park w-60"><%=  @park.name %><p>
+    <p class="text-park text-3xl md:text-4xl py-3 px-8 border-b-2 border-park w-auto"><%=  @park.name %><p>
   </div>
   <p class="text-park py-5 md:pb-20">キャッチフレーズ<p>
 </div>
@@ -59,37 +59,30 @@
         </dialog>
     </div>
   </div>
-</div>
 
+  <div class="flex justify-center items-center flex-col py-10">
+    <div style="width: 90%; height: 300px;">
+      <%= render 'shared/map' %>
+    </div>
 
-<div class="flex justify-center items-center flex-col">
-  <div style="width: 90%; height: 300px;">
-    <%= render 'shared/map' %>
-  </div>
-
-  <div class="py-5">
-    <p class="text-xl md:text-2xl text-park font-bold py-5 text-center">- みんなの投稿 -<p>
-  </div>
-  <div class="px-8 flex justify-center items-center md:justify-between flex-col md:flex-row md:gap-x-5 gap-y-8 pb-8  grid md:grid-cols-4">
-    <% @park_reports.each do |park_report| %>
-      <div class="card bg-base-100 shadow-xl flex flex-col md:gap-x-10" style="height: 380px;">
-        <figure>
-          <div>
-            <% park_report.report_images.each do |report_image| %>
-              <% if report_image.url.present? %>
-                <%= image_tag report_image.url.url, class: "w-full h-auto object-cover"%>
-              <% end %>
-            <% end %>
+    <div class="py-5">
+      <p class="text-xl md:text-2xl text-park font-bold py-5 text-center">- みんなの投稿 -<p>
+    </div>
+    <div class="px-8 flex justify-center items-center md:justify-between flex-col md:flex-row md:gap-x-5 gap-y-8 pb-8  grid md:grid-cols-4">
+      <% @park_reports.each do |park_report| %>
+        <div class="card bg-base-100 shadow-xl flex flex-col md:gap-x-10" style="height: 380px;">
+          <figure>
+            <div>
+              <%= image_tag park_report.report_images.first.url.url, class: "w-full h-auto object-cover"%>
+            </div>
+          </figure>
+          <div class="card-body bg-white rounded-lg">
+              <p><%= park_report.date %></p>
+              <p><%= park_report.user.name %>さん</p>
+            <%= link_to "#{park_report.comment}", park_report_path(park_report), class: "card-title" %>
           </div>
-        </figure>
-
-        <div class="card-body bg-white rounded-full">
-            <p><%= park_report.date %></p>
-            <p><%= park_report.user.name %>さん</p>
-          <h2 class="card-title"><%= park_report.comment %></h2>
         </div>
-      </div>
-    <% end %>
+      <% end %>
+    </div>
   </div>
 </div>
-


### PR DESCRIPTION
**投稿詳細ページのレイアウトを作成しました。**
・投稿の画像が複数枚ある時、最初の一枚が公園詳細の投稿画像になるよう設定しました。
・２枚目以降の画像は、投稿詳細ページから見られるよう設定しました。
・公園詳細ページにある投稿のコメント部分から、投稿詳細に遷移するようリンクを配置しました。
・公園詳細ページのトップ画像がない場合、現状は何も表示されない仕様になっています。


![5fe3734745b2217e053e8ba99f33bc2f](https://github.com/yamazaki-yuri/tokyopicnic/assets/151484437/2b046ed9-3a3c-4d42-8110-1ea664c3a350)

Closes #19 