### PR TITLE
ParkReportにtitleカラムの追加

### DIFF
--- a/app/controllers/park_reports_controller.rb
+++ b/app/controllers/park_reports_controller.rb
@@ -52,11 +52,11 @@ class ParkReportsController < ApplicationController
   end
 
   def report_params
-    params.require(:park_report).permit(:date, :comment, report_images_attributes: [:url]).merge(park_id: @park.id, tokyo_ward_id: @tokyo_ward.id)
+    params.require(:park_report).permit(:date, :title, :comment, report_images_attributes: [:url]).merge(park_id: @park.id, tokyo_ward_id: @tokyo_ward.id)
   end
 
   def edit_params
-    params.require(:park_report).permit(:date, :comment)
+    params.require(:park_report).permit(:date, :title, :comment)
   end
 
   def save_park_report

--- a/app/models/park_report.rb
+++ b/app/models/park_report.rb
@@ -4,4 +4,6 @@ class ParkReport < ApplicationRecord
   belongs_to :tokyo_ward
   has_many :report_images
   accepts_nested_attributes_for :report_images
+
+  validates :title, presence: true
 end

--- a/app/views/park_reports/_edit.html.erb
+++ b/app/views/park_reports/_edit.html.erb
@@ -4,6 +4,10 @@
     <%= f.date_field :date, class: "block shadow rounded-md border border-gray-200 outline-none px-3 py-2 mt-2 w-full" %>
   </div>
   <div class="mt-8 mb-8 flex flex-col px-5">
+    <%= f.label :title, "タイトル" %>
+    <%= f.text_field :title, placeholder: '思ったことを自由に記入', class: "textarea textarea-primary" %>
+  </div>
+  <div class="mt-8 mb-8 flex flex-col px-5">
     <%= f.label :comment, "ひとこと" %>
     <%= f.text_field :comment, placeholder: '思ったことを自由に記入', class: "textarea textarea-primary" %>
   </div>

--- a/app/views/park_reports/new.html.erb
+++ b/app/views/park_reports/new.html.erb
@@ -24,6 +24,10 @@
             </div>
           <% end %>
         <div class="mt-8 mb-8 flex flex-col px-5">
+          <%= f.label :title, "タイトル(必須)" %>
+          <%= f.text_field :title, placeholder: 'どんな公園だった？', class: "textarea textarea-primary" %>
+        </div>
+        <div class="mt-8 mb-8 flex flex-col px-5">
           <%= f.label :comment, "ひとこと" %>
           <%= f.text_field :comment, placeholder: '思ったことを自由に記入', class: "textarea textarea-primary" %>
         </div>

--- a/app/views/park_reports/show.html.erb
+++ b/app/views/park_reports/show.html.erb
@@ -31,10 +31,10 @@
         <% end %>
       </div>
       <div class="border-b-2 border-slate-200 pb-1 text-park">
-        <p class="pl-8"><%= @park_report.comment %><p>
+        <p class="pl-8"><%= @park_report.title %><p>
       </div>
       <div class="border-b-2 border-slate-200 pb-1 text-park">
-        <p class="pl-8">この日は朝からカラオケにいてセカオワのライブの予習をしてた。数年ぶりのカラオケ楽しかった！ライブ前にセカオワファンの集合写真に混ざって写った笑ライブ魔の時間潰しに代々木公園にいったら、人がたくさんいた。<p>
+        <p class="pl-8"><%= @park_report.comment %><p>
       </div>
     </div>
   </div>

--- a/app/views/parks/show.html.erb
+++ b/app/views/parks/show.html.erb
@@ -79,7 +79,7 @@
           <div class="card-body bg-white rounded-lg">
               <p><%= park_report.date %></p>
               <p><%= park_report.user.name %>さん</p>
-            <%= link_to "#{park_report.comment}", park_report_path(park_report), class: "card-title" %>
+            <%= link_to "#{park_report.title}", park_report_path(park_report), class: "card-title" %>
           </div>
         </div>
       <% end %>

--- a/db/migrate/20240513130319_add_title_to_park_reports.rb
+++ b/db/migrate/20240513130319_add_title_to_park_reports.rb
@@ -1,0 +1,5 @@
+class AddTitleToParkReports < ActiveRecord::Migration[7.1]
+  def change
+    add_column :park_reports, :title, :string, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_05_11_063443) do
+ActiveRecord::Schema[7.1].define(version: 2024_05_13_130319) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -30,6 +30,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_05_11_063443) do
     t.text "comment"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "title", null: false
     t.index ["park_id"], name: "index_park_reports_on_park_id"
     t.index ["tokyo_ward_id"], name: "index_park_reports_on_tokyo_ward_id"
     t.index ["user_id"], name: "index_park_reports_on_user_id"


### PR DESCRIPTION
**ユーザーの投稿に、titleカラムを追加しました。**
・ParkReportテーブルに、新たにtitleカラムをnull falseで作成しました
 ・公園詳細ページにあるみんなの投稿にあるリンクの部分をcommentからtitleに変更しました
 ・park_reports/show.htmlの投稿カードにある静的テキストを、ユーザーのcomment内容に変更しました
 ・新規投稿にtitileを追加しました
・ 投稿編集にtitleを追加しました

Closes #89 