### PR TITLE
投稿詳細画面での画像の追加と削除機能の実装

### DIFF
--- a/app/controllers/park_images_controller.rb
+++ b/app/controllers/park_images_controller.rb
@@ -4,10 +4,10 @@ class ParkImagesController < ApplicationController
     @park_image = @park.park_images.build(park_image_params)
 
     if @park_image.save
-      flash[:success] = "画像を投稿しました"
+      flash[:success] = "画像を追加しました"
       redirect_to @park
     else
-      flash[:danger] = "投稿に失敗しました"
+      flash[:danger] = "画像の追加に失敗しました"
       render 'parks/show', status: :unprocessable_entity
     end
   end

--- a/app/controllers/park_reports_controller.rb
+++ b/app/controllers/park_reports_controller.rb
@@ -43,6 +43,7 @@ class ParkReportsController < ApplicationController
 
   def show
     @park_report = ParkReport.includes(:report_images, :park).find(params[:id])
+    @report_image = ReportImage.new
   end
 
   private

--- a/app/controllers/report_images_controller.rb
+++ b/app/controllers/report_images_controller.rb
@@ -1,0 +1,20 @@
+class ReportImagesController < ApplicationController
+  def create
+    @park_report = ParkReport.find(params[:report_image][:park_report_id])
+    @report_image = @park_report.report_images.build(report_image_params)
+
+    if @report_image.save
+      flash[:success] = "画像を追加しました"
+      redirect_to @park_report
+    else
+      flash[:danger] = "画像の追加に失敗しました"
+      render 'park_reports/show', status: :unprocessable_entity
+    end
+  end
+
+  private
+
+  def report_image_params
+    params.require(:report_image).permit(:url).merge(park_report_id: @park_report.id)
+  end
+end

--- a/app/controllers/report_images_controller.rb
+++ b/app/controllers/report_images_controller.rb
@@ -12,6 +12,15 @@ class ReportImagesController < ApplicationController
     end
   end
 
+  def destroy
+    @report_image = ReportImage.find(params[:id])
+    @park_report = @report_image.park_report
+    @report_image.remove_url!
+    @report_image.destroy!
+    flash[:success] = "画像を削除しました"
+    redirect_to @park_report, status: :see_other
+  end
+
   private
 
   def report_image_params

--- a/app/views/park_images/_form.html.erb
+++ b/app/views/park_images/_form.html.erb
@@ -1,6 +1,6 @@
 <%= form_with(model: @park_image, remote: true, local: true, url: park_images_path, class: "justify-between item-center") do |f| %>
   <%= f.hidden_field :park_id, value: @park.id %>
-  <div class="field px-2">
+    <div class="field px-2">
   <%= f.file_field :url, class: "file-input file-input-bordered file-input-accent w-full max-w-xs" %>
   </div>
   <div class="btn btn-ghost rounded-btn hover:bg-slate-200 text-park mt-5 w-full">

--- a/app/views/park_reports/show.html.erb
+++ b/app/views/park_reports/show.html.erb
@@ -55,8 +55,8 @@
     <button class="btn" onclick="add_image.showModal()">画像を追加する</button>
     <dialog id="add_image" class="modal">
       <div class="modal-box">
-        <h3 class="font-bold text-lg">Hello!</h3>
-        <p class="py-4">Press ESC key or click outside to close</p>
+        <p class="text-park font-bold pb-5 text-center">画像を選択してね</p>
+        <%= render 'report_images/form', report_image: @report_image %>
       </div>
       <form method="dialog" class="modal-backdrop">
         <button>close</button>

--- a/app/views/park_reports/show.html.erb
+++ b/app/views/park_reports/show.html.erb
@@ -2,7 +2,9 @@
   <div class="card bg-base-100 shadow-xl flex flex-col md:flex-row w-full h-auto md:h-full object-cover">
     <figure class="rounded-md">
       <div>
-        <%= image_tag @park_report.report_images.first.url.url %>
+        <% if @park_report.report_images.present? %>
+          <%= image_tag @park_report.report_images.first.url.url %>
+        <% end %>
       </div>
     </figure>
   </div>
@@ -41,12 +43,23 @@
 
   <div class="flex justify-center items-center md:justify-between flex-col md:flex-row md:gap-x-5 gap-y-8 py-10 px-8 grid md:grid-cols-4 ">
     <% @park_report.report_images.each do |report_image| %>
-      <div class="card bg-base-100 shadow-xl flex flex-col md:gap-x-10 rounded-lg" >
-        <figure>
-          <div>
-            <%= image_tag report_image.url.url, class: "w-full h-auto object-cover rounded-lg "%>
+      <div>
+        <div class="card bg-base-100 shadow-xl flex flex-col md:gap-x-10 rounded-lg" >
+          <figure>
+            <div>
+            <% if report_image.url.present? %>
+              <%= image_tag report_image.url.url, class: "w-full h-auto object-cover rounded-lg "%>
+            <% end %>
+            </div>
+          </figure>
+        </div>
+        <% if current_user.own?(@park_report) %>
+          <div class="pt-3">
+            <%= link_to report_image_path(report_image), data: { turbo_method: :delete, turbo_confirm: '画像を削除しますか？'} do %>
+              <i class="fa-regular fa-trash-can"></i>
+            <% end %>
           </div>
-        </figure>
+        <% end %>
       </div>
     <% end %>
   </div>

--- a/app/views/parks/show.html.erb
+++ b/app/views/parks/show.html.erb
@@ -73,7 +73,9 @@
         <div class="card bg-base-100 shadow-xl flex flex-col md:gap-x-10" style="height: 380px;">
           <figure>
             <div>
-              <%= image_tag park_report.report_images.first.url.url, class: "w-full h-auto object-cover"%>
+              <% if park_report.report_images.present? %>
+                <%= image_tag park_report.report_images.first.url.url, class: "w-full h-auto object-cover"%>
+              <% end %>
             </div>
           </figure>
           <div class="card-body bg-white rounded-lg">

--- a/app/views/report_images/_form.html.erb
+++ b/app/views/report_images/_form.html.erb
@@ -1,0 +1,9 @@
+<%= form_with(model: @report_image, remote: true, local: true, url: report_images_path, class: "justify-between item-center") do |f| %>
+  <%= f.hidden_field :park_report_id, value: @park_report.id %>
+  <div class="field px-2">
+    <%= f.file_field :url, class: "file-input file-input-bordered file-input-accent w-full max-w-xs" %>
+  </div>
+  <div class="btn btn-ghost rounded-btn hover:bg-slate-200 text-park mt-5 w-full">
+    <%= f.submit '追加する' %>
+  </div>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,7 +6,7 @@ Rails.application.routes.draw do
   resources :park_reports, only: [:new, :create, :show, :edit, :update]
   resources :parks, only: [:show]
   resources :park_images, only: [:new, :create]
-  resources :report_images, only: [:new, :create]
+  resources :report_images, only: [:new, :create, :destroy]
   
   root 'tops#index'
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,6 +6,7 @@ Rails.application.routes.draw do
   resources :park_reports, only: [:new, :create, :show, :edit, :update]
   resources :parks, only: [:show]
   resources :park_images, only: [:new, :create]
+  resources :report_images, only: [:new, :create]
   
   root 'tops#index'
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html


### PR DESCRIPTION
### ユーザーの投稿詳細画面で、画像の追加と削除ができるよう実装しました
 **画像追加機能の流れは以下の通りです**
1. 投稿詳細ページにある**画像を追加する**をクリックすると、画像追加フォームのモーダルが表示される
2. ファイルを選択して、追加するをクリックする
3. 画像が保存されると、**画像を追加しました**というフラッシュメッセージが表示され、投稿詳細画面に遷移する

**画像削除機能の流れは以下の通りです**
1. 画像の下にあるゴミ箱のアイコン(投稿者のみの表示)をクリックする
2. 画面上部に**画像を削除しますか？**という確認が表示される
3. OKを押すと画像が削除され、**画像を削除しました**というフラッシュメッセージが表示される
4. 投稿詳細ページに遷移する

![12c76a0c9f82bdf06a1cec89d69bdeab](https://github.com/yamazaki-yuri/tokyopicnic/assets/151484437/fef1d0d4-feb7-4143-87b4-1a680a68ea4a)

Closes #90 

