### PR TITLE
投稿の削除

### DIFF
--- a/app/controllers/park_reports_controller.rb
+++ b/app/controllers/park_reports_controller.rb
@@ -1,6 +1,7 @@
 class ParkReportsController < ApplicationController
   before_action :authenticate_user!
-  before_action :find_report, only: %i[edit update]
+  before_action :find_current_user_report, only: %i[edit update]
+  before_action :find_report, only: %i[show destroy]
   
   def new
     @park_report = ParkReport.new
@@ -42,14 +43,29 @@ class ParkReportsController < ApplicationController
 
 
   def show
-    @park_report = ParkReport.includes(:report_images, :park).find(params[:id])
     @report_image = ReportImage.new
+  end
+
+  def destroy
+    @park = @park_report.park
+    if @park_report.destroy
+      
+      flash[:success] = "投稿を削除しました"
+      redirect_to @park
+    else
+      flash.now[:danger] = "投稿の削除に失敗しました"
+      render :show, status: :unprocessable_entity
+    end
   end
 
   private
 
-  def find_report
+  def find_current_user_report
     @park_report = current_user.park_reports.find(params[:id])
+  end
+
+  def find_report
+    @park_report = ParkReport.includes(:report_images, :park).find(params[:id])
   end
 
   def report_params

--- a/app/controllers/report_images_controller.rb
+++ b/app/controllers/report_images_controller.rb
@@ -17,7 +17,7 @@ class ReportImagesController < ApplicationController
     @park_report = @report_image.park_report
     @report_image.remove_url!
     @report_image.destroy!
-    flash[:success] = "画像を削除しました"
+    flash.now[:success] = "画像を削除しました"
     redirect_to @park_report, status: :see_other
   end
 

--- a/app/models/park_report.rb
+++ b/app/models/park_report.rb
@@ -2,7 +2,7 @@ class ParkReport < ApplicationRecord
   belongs_to :user
   belongs_to :park
   belongs_to :tokyo_ward
-  has_many :report_images
+  has_many :report_images, dependent: :destroy
   accepts_nested_attributes_for :report_images
 
   validates :title, presence: true

--- a/app/views/park_reports/show.html.erb
+++ b/app/views/park_reports/show.html.erb
@@ -28,7 +28,9 @@
         </dialog>
         <% if current_user.own?(@park_report) %>
           <div class="pr-5">
-            <i class="fa-solid fa-trash-can"></i>
+            <%= link_to park_report_path(@park_report), data: { turbo_method: :delete, turbo_confirm: '投稿を削除しますか？画像も全て削除されます。'} do %>
+              <i class="fa-solid fa-trash-can"></i>
+            <% end %>
           </div>
         <% end %>
       </div>
@@ -65,15 +67,17 @@
   </div>
 
   <div class="flex justify-center items-center">
-    <button class="btn" onclick="add_image.showModal()">画像を追加する</button>
-    <dialog id="add_image" class="modal">
-      <div class="modal-box">
-        <p class="text-park font-bold pb-5 text-center">画像を選択してね</p>
-        <%= render 'report_images/form', report_image: @report_image %>
-      </div>
-      <form method="dialog" class="modal-backdrop">
-        <button>close</button>
-      </form>
-    </dialog>
+    <% if current_user.own?(@park_report) %>
+      <button class="btn" onclick="add_image.showModal()">画像を追加する</button>
+      <dialog id="add_image" class="modal">
+        <div class="modal-box">
+          <p class="text-park font-bold pb-5 text-center">画像を選択してね</p>
+          <%= render 'report_images/form', report_image: @report_image %>
+        </div>
+        <form method="dialog" class="modal-backdrop">
+          <button>close</button>
+        </form>
+      </dialog>
+    <% end %>
   </div>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,7 +3,7 @@ Rails.application.routes.draw do
     sessions: 'users/sessions',
     omniauth_callbacks: 'users/omniauth_callbacks'
   }
-  resources :park_reports, only: [:new, :create, :show, :edit, :update]
+  resources :park_reports
   resources :parks, only: [:show]
   resources :park_images, only: [:new, :create]
   resources :report_images, only: [:new, :create, :destroy]


### PR DESCRIPTION
### 投稿詳細ページから、ユーザーの投稿を削除できるようにしました
**削除機能の流れは以下の通りです**
1. ユーザーの投稿詳細のカードにあるゴミ箱のアイコン(投稿者の場合のみ表示)を押す
2. **投稿を削除しますか？画像も全て削除されます**という確認が表示される
3. OKを押すと削除が実行される
4. **投稿を削除しました**というフラッシュメッセージが表示され、公園詳細ページに遷移する

・投稿詳細ページの**画像を追加する**というボタンについても、投稿者の投稿時のみ表示されるように変更しました。

![f70c239761debbee8c823909da381e2e](https://github.com/yamazaki-yuri/tokyopicnic/assets/151484437/40e07bc9-3b86-4269-b037-42875cb128d5)

Closes #93 