### PR TITLE
マイページの追加

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -7,7 +7,7 @@ class ApplicationController < ActionController::Base
     devise_parameter_sanitizer.permit(:sign_up, keys: [:name])
   end
 
-  def after_sign_out_path_for(resource_or_scope)
-    new_user_session_path #ここを好きなパスに変更
-  end
+  def after_sign_in_path_for(resource)
+    mypage_path
+  end 
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,0 +1,6 @@
+class UsersController < ApplicationController
+  before_action :authenticate_user!
+  def index
+    @park_reports = current_user.park_reports.includes(:park, :report_images).order(created_at: :desc)
+  end
+end

--- a/app/views/park_reports/show.html.erb
+++ b/app/views/park_reports/show.html.erb
@@ -12,7 +12,7 @@
     <div class="card-body bg-white rounded-md w-full h-auto md:h-full object-cover">
         <h2 class="card-title pb-2 pl-3 border-b-2 border-slate-200 text-park">
           <%= link_to "#{@park_report.park.name}", "#{park_path(@park_report.park)}" %>
-          <%= link_to '公式サイト', "#{@park_report.park.website_url}", class: "badge badge-secondary border-b-2 border-park text-park" %>
+          <%= link_to '公式サイト', "#{@park_report.park.website_url}", class: "badge badge border-b-2 border-park text-park" %>
         </h2>
         <div class="flex justify-between border-b-2 border-slate-200 pb-1 text-park">
           <p class="pl-8"><%= @park_report.date %></p>

--- a/app/views/parks/show.html.erb
+++ b/app/views/parks/show.html.erb
@@ -22,7 +22,7 @@
     <div class="card-body bg-white rounded-md w-full h-auto md:h-full object-cover">
         <h2 class="card-title pb-2 pl-3 border-b-2 border-slate-200 text-park">
           公式サイト
-          <%= link_to 'こちら', "#{@park.website_url}", class: "badge badge-secondary border-b-2 border-park text-park" %>
+          <%= link_to 'こちら', "#{@park.website_url}", class: "badge badge border-b-2 border-park text-park" %>
         </h2>
         <div class="flex justify-between border-b-2 border-slate-200 pb-1 text-park">
           <p class="w-1/3 pl-8"><i class="fa-solid fa-yen-sign pr-5"></i>料金</p>

--- a/app/views/shared/_before_login_header.html.erb
+++ b/app/views/shared/_before_login_header.html.erb
@@ -15,7 +15,7 @@
             <%= link_to '新規投稿', new_park_report_path, class: "text-park font-semibold hover:bg-slate-200 rounded-lg px-4 py-2" %>
           </li>
           <li>
-            <%= link_to 'マイページ', '#', class: "text-park font-semibold hover:bg-slate-200 rounded-lg px-4 py-2" %>
+            <%= link_to 'マイページ', mypage_path, class: "text-park font-semibold hover:bg-slate-200 rounded-lg px-4 py-2" %>
           </li>
           <li>
             <%= link_to 'プロフィール編集', '#', class: "text-park font-semibold hover:bg-slate-200 rounded-lg px-4 py-2" %>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -15,7 +15,7 @@
             <%= link_to '新規投稿', new_park_report_path, class: "text-park font-semibold hover:bg-slate-200 rounded-lg px-4 py-2" %>
           </li>
           <li>
-            <%= link_to 'マイページ', '#', class: "text-park font-semibold hover:bg-slate-200 rounded-lg px-4 py-2" %>
+            <%= link_to 'マイページ', mypage_path, class: "text-park font-semibold hover:bg-slate-200 rounded-lg px-4 py-2" %>
           </li>
           <li>
             <%= link_to 'プロフィール編集', '#', class: "text-park font-semibold hover:bg-slate-200 rounded-lg px-4 py-2" %>

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -1,0 +1,29 @@
+<div class="flex-grow container mx-auto px-6 py-10">
+  <div class="flex justify-center items-center">
+    <div class="text-2xl md:text-3xl lg:text-4xl text-park text-center font-bold pt-10 pb-5 px-8 border-b-2 border-park">
+      <%= current_user.name %>さんのページ
+    </div>
+  </div>
+
+  <div class="py-5">
+    <p class="text-xl md:text-2xl text-park font-bold py-5 text-center">- 投稿一覧 -</p>
+  </div>
+  <div class="px-8 flex justify-center items-center md:justify-between flex-col md:flex-row gap-y-8 xl:gap-x-5 lg:gap-x-5 sm:gap-x-5 pb-8  grid xl:grid-cols-4 lg:grid-cols-3  sm:grid-cols-2">
+    <% @park_reports.each do |park_report| %>
+      <div class="card bg-base-100 shadow-xl flex flex-col md:gap-x-10" style="height: 380px;">
+        <figure>
+          <div>
+            <% if park_report.report_images.present? %>
+              <%= image_tag park_report.report_images.first.url.url, class: "w-full h-auto object-cover"%>
+            <% end %>
+          </div>
+        </figure>
+        <div class="card-body bg-white rounded-lg">
+            <p><%= park_report.date %></p>
+          <%= link_to "#{park_report.park.name}", park_path(park_report.park), class: "card-title pb-2 border-b-2 border-slate-200" %>
+          <%= link_to "#{park_report.title}", park_report_path(park_report), class: "pl-5 text-park font-bold" %>
+        </div>
+      </div>
+    <% end %>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,6 +10,7 @@ Rails.application.routes.draw do
   
   root 'tops#index'
   get '/search', to: 'parks#index', as: 'search'
+  get '/mypage', to: 'users#index'
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
 
   # Reveal health status on /up that returns 200 if the app boots with no exceptions, otherwise 500.


### PR DESCRIPTION
**ユーザーのマイページを作成しました**
・ヘッダーのマイページから、マイページに遷移するように実装しました
・ログイン後、マイページに遷移するように修正しました
・ログアウト後、トップページに遷移するよう修正しました
・マイページにはユーザーの投稿一覧を表示しました
　・カード内の公園名をクリックすると公園詳細ページに遷移します
　・カード内の投稿タイトルをクリックすると、投稿詳細ページに遷移します

![85af4a5a95e59300608ad84ea5374461](https://github.com/yamazaki-yuri/tokyopicnic/assets/151484437/60d183e0-2142-4803-95e6-3adc65b029cd)

![9364bec8a4b4e4ccffd1059914dc59cd](https://github.com/yamazaki-yuri/tokyopicnic/assets/151484437/4a8c84e3-b059-41ce-a4fd-68014a3b3763)

Closes #17 
