### PR TITLE
Feature profile

### DIFF
--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -1,0 +1,28 @@
+class ProfilesController < ApplicationController
+  before_action :authenticate_user!
+  before_action :set_user, only: %i[show edit update]
+
+  def show; end
+
+  def edit; end
+
+  def update
+    if @user.update(user_params)
+      flash[:notice] = '更新しました'
+      redirect_to profile_path
+    else
+      flash.now['alert'] = '更新できませんでした'
+      render :edit, status: :unprocessable_entity
+    end
+  end
+
+  private
+
+  def set_user
+    @user = User.find(current_user.id)
+  end
+
+  def user_params
+    params.require(:user).permit(:name, :email)
+  end
+end

--- a/app/views/parks/_search_form.html.erb
+++ b/app/views/parks/_search_form.html.erb
@@ -1,45 +1,52 @@
-<div class="card bg-base-100 shadow-xl mb-5 md:w-1/2">
-  <div class="card-body">
-    <div class="pb-1 text-park font-bold">
-      - 公園名で探す -
-    </div>
-    <%= search_form_for @q do |f| %>
-      <div class="pb-5 border-b-2 border-slate-200">
-        <%= f.text_field :name_cont_any, placeholder: "公園名を入力してください", class: "input input-bordered input-primary w-full", style: "height: 40px;" %>
+<%= turbo_frame_tag "messages" do %>
+  <div class="card bg-base-100 shadow-xl mb-5 md:w-1/2">
+    <div class="card-body">
+      <div class="pb-1 text-park font-bold">
+        - 公園名で探す -
       </div>
-      <div class="pt-5">
-        <div class="pb-1 text-park font-bold">
+      <%= search_form_for @q do |f| %>
+        <div class="pb-5 border-b-2 border-slate-200">
+          <%= f.text_field :name_cont_any, placeholder: "公園名を入力してください", class: "input input-bordered input-success w-full", style: "height: 40px;" %>
+        </div>
+        <div class="pt-5 text-park font-bold">
           - 条件で絞り込む -
         </div>
-        <div class="pb-2 text-park">
-          <%= f.radio_button :fee, "paid" %>
-          <%= f.label :fee, "有料" %>
-          <%= f.radio_button :fee, "free" %>
-          <%= f.label :fee, "無料" %>
+        <div class="pt-2 flex justify-between flex-row">
+          <div>
+            <div class="pb-2 text-park">
+              <%= f.collection_select :fee, [["有料", "paid"], ["無料", "free"]], :last, :first, { prompt: '料金は？' }, class: "select select-success max-w-xs" %>
+            </div>
+            <div class="pb-2 text-park">
+              <%= f.collection_select :tokyo_wards_id_eq, TokyoWard.all, :id, :name, { prompt: '区を選択' }, class: "select select-success max-w-xs" %>
+            </div>
+          </div>
+          <div class="w-2/3 md:pl-3 lg:pl-0">
+            <div class="text-park">
+              <%= f.check_box :food_allowed_in, { multiple: true }, "possible", nil  %>
+              <i class="fa-solid fa-utensils">
+              <%= f.label :food_allowed_in_possible, "飲食可" %></i>
+            </div>
+            <div class="text-park">
+              <%= f.check_box :alcohol_allowed_in, { multiple: true }, "possible", nil %>
+              <i class="fa-solid fa-champagne-glasses">
+              <%= f.label :alcohol_allowed_in_possible, "お酒飲んでいい" %></i>
+            </div>
+            <div class="text-park">
+              <%= f.check_box :sheet_available_in, { multiple: true }, "possible", nil %>
+              <i class="fa-solid fa-bacon">
+              <%= f.label :sheet_available_in_possible, "シートを敷ける" %></i>
+            </div>
+            <div class="text-park">
+              <%= f.check_box :bringing_in_play_equipment_in, { multiple: true }, "possible", nil %>
+              <i class="fa-solid fa-futbol">
+              <%= f.label :bringing_in_play_equipment_in_possible, "遊具で遊んでいい" %></i>
+            </div>
+          </div>
         </div>
-        <div>
-          <%= f.collection_select :tokyo_wards_id_eq, TokyoWard.all, :id, :name, { prompt: '区を選択' }, class: "input input-bordered input-primary", style: "height: 30px;" %>
+        <div class="btn btn-sm btn-secondary mt-3">
+          <%= f.submit "検索", data: { turbo_frame: "_top" } %>
         </div>
-      </div>
-      <div class="pt-3">
-        <%= f.check_box :food_allowed_in, { multiple: true }, "possible", nil  %>
-        <%= f.label :food_allowed_in_possible, "飲食可", class: "text-park" %>
-      </div>
-      <div>
-        <%= f.check_box :alcohol_allowed_in, { multiple: true }, "possible", nil %>
-        <%= f.label :alcohol_allowed_in_possible, "お酒飲んでいい", class: "text-park" %>
-      </div>
-      <div>
-        <%= f.check_box :sheet_available_in, { multiple: true }, "possible", nil %>
-        <%= f.label :sheet_available_in_possible, "シートを敷ける", class: "text-park" %>
-      </div>
-      <div>
-        <%= f.check_box :bringing_in_play_equipment_in, { multiple: true }, "possible", nil %>
-        <%= f.label :bringing_in_play_equipment_in_possible, "遊具で遊んでいい", class: "text-park" %>
-      </div>
-      <div class="btn btn-sm btn-secondary mt-3">
-        <%= f.submit "検索" %>
-      </div>
-    <% end %>
+      <% end %>
+    </div>
   </div>
-</div>
+<% end %>

--- a/app/views/profiles/edit.html.erb
+++ b/app/views/profiles/edit.html.erb
@@ -2,6 +2,10 @@
   <div class="flex justify-center items-center py-10">
     <div class="card w-96 bg-base-100 shadow-xl">
       <div class="card-body">
+      <% is_google_account = @user.sns_credential_ids.present? %>
+        <% if is_google_account %>
+          <p class="text-sm pb-3 text-indigo-500">Googleアカウントの為メールの編集はできません<p>
+        <% end %>
       <%= form_with model: @user, url: profile_path(@user), local: true do |f| %>
         <div class="flex justify-center border-b-2 border-slate-200 pb-1">
           <p class="font-bold">名前</p>
@@ -11,9 +15,13 @@
         </div>
         <div class="flex justify-center border-b-2 border-slate-200 pt-4 pb-1">
           <p class="font-bold">メール</p>
-          <p class="text-park">
-            <%= f.text_field :email, autofocus: true, autocomplete: "email", class: "pl-3 mt-1 block placeholder-gray-400 rounded-lg border-2 border-gray-200" %>
-          </p>
+          <% if is_google_account %>
+            <p class="pl-3 mt-1 block placeholder-gray-400 rounded-lg border-2 border-gray-200"><%= current_user.email%></p>
+          <% else %>
+            <p class="text-park">
+              <%= f.text_field :email, autofocus: true, autocomplete: "email", class: "pl-3 mt-1 block placeholder-gray-400 rounded-lg border-2 border-gray-200" %>
+            </p>
+          <% end %>
         </div>
         <div class="pt-7 w-full">
           <%= f.submit '更新', class: "btn btn-secondary me-2 w-full" %>

--- a/app/views/profiles/edit.html.erb
+++ b/app/views/profiles/edit.html.erb
@@ -1,0 +1,28 @@
+<%= turbo_frame_tag current_user do %>
+  <div class="flex justify-center items-center py-10">
+    <div class="card w-96 bg-base-100 shadow-xl">
+      <div class="card-body">
+      <%= form_with model: @user, url: profile_path(@user), local: true do |f| %>
+        <div class="flex justify-center border-b-2 border-slate-200 pb-1">
+          <p class="font-bold">名前</p>
+          <p class="text-park pl-4">
+            <%= f.text_field :name, autofocus: true, autocomplete: "name", class: "pl-3 mt-1 block placeholder-gray-400 rounded-lg border-2 border-gray-200" %>
+          </p>
+        </div>
+        <div class="flex justify-center border-b-2 border-slate-200 pt-4 pb-1">
+          <p class="font-bold">メール</p>
+          <p class="text-park">
+            <%= f.text_field :email, autofocus: true, autocomplete: "email", class: "pl-3 mt-1 block placeholder-gray-400 rounded-lg border-2 border-gray-200" %>
+          </p>
+        </div>
+        <div class="pt-7 w-full">
+          <%= f.submit '更新', class: "btn btn-secondary me-2 w-full" %>
+        </div>
+        <div class="text-center text-park pt-12">
+          <%= link_to 'パスワード変更はこちら', "#" %>
+        </div>
+      <% end %>
+      </div>
+    </div>
+  </div>
+<% end %>

--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -1,0 +1,29 @@
+<div class="flex-grow container mx-auto px-6 py-10">
+  <div class="flex justify-center items-center">
+    <div class="text-2xl md:text-3xl lg:text-4xl text-park text-center font-bold pt-10 pb-5 px-8 border-b-2 border-park">
+      <%= current_user.name %>さんのプロフィール
+    </div>
+  </div>
+  <%= turbo_frame_tag current_user do %>
+  <div class="flex justify-center items-center py-10">
+    <div class="card w-96 bg-base-100 shadow-xl">
+      <div class="card-body">
+        <div class="flex justify-center border-b-2 border-slate-200 pb-3">
+          <p class="font-bold">名前</p>
+          <p class="text-park"><%= current_user.name %></P>
+        </div>
+        <div class="flex justify-center border-b-2 border-slate-200 pt-2 pb-3">
+          <p class="font-bold">メール</p>
+          <p class="text-park"><%= current_user.email %></p>
+        </div>
+        <div class="pt-5 w-full">
+          <%= link_to "編集", edit_profile_path, class: "btn btn-secondary me-2 w-full" %>
+        </div>
+        <div class="text-center text-park pt-10">
+          <%= link_to 'パスワード変更はこちら', "#" %>
+        </div>
+      </div>
+    </div>
+  </div>
+  <% end %>
+</div>

--- a/app/views/shared/_before_login_header.html.erb
+++ b/app/views/shared/_before_login_header.html.erb
@@ -18,7 +18,7 @@
             <%= link_to 'マイページ', mypage_path, class: "text-park font-semibold hover:bg-slate-200 rounded-lg px-4 py-2" %>
           </li>
           <li>
-            <%= link_to 'プロフィール編集', '#', class: "text-park font-semibold hover:bg-slate-200 rounded-lg px-4 py-2" %>
+            <%= link_to 'プロフィール編集', profile_path, class: "text-park font-semibold hover:bg-slate-200 rounded-lg px-4 py-2" %>
           </li>
           <li>
             <%= link_to '新規登録', new_user_registration_path, class: "text-park font-semibold hover:bg-slate-200 rounded-lg px-4 py-2" %>

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -8,7 +8,7 @@
   <nav class="p-3">
     <h6 class="footer-title text-slate-100">Personal</h6> 
     <%= link_to 'ユーザー登録', new_user_registration_path, class: "link link-hover text-slate-100" %>
-    <%= link_to 'マイページ', '#', class: "link link-hover text-slate-100" %>
+    <%= link_to 'マイページ', mypage_path, class: "link link-hover text-slate-100" %>
     <%= link_to 'ログイン', new_user_session_path, class: "link link-hover text-slate-100" %>
   </nav> 
   <nav class="p-3">

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -18,7 +18,7 @@
             <%= link_to 'マイページ', mypage_path, class: "text-park font-semibold hover:bg-slate-200 rounded-lg px-4 py-2" %>
           </li>
           <li>
-            <%= link_to 'プロフィール編集', '#', class: "text-park font-semibold hover:bg-slate-200 rounded-lg px-4 py-2" %>
+            <%= link_to 'プロフィール編集', profile_path, class: "text-park font-semibold hover:bg-slate-200 rounded-lg px-4 py-2" %>
           </li>
           <li>
             <%= link_to 'ログアウト', destroy_user_session_path, data: { turbo_method: :delete}, class: "text-park font-semibold hover:bg-slate-200 rounded-lg px-4 py-2" %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,6 +7,7 @@ Rails.application.routes.draw do
   resources :parks, only: [:show, :index]
   resources :park_images, only: [:new, :create]
   resources :report_images, only: [:new, :create, :destroy]
+  resource :profile, only: %i[show edit update]
   
   root 'tops#index'
   get '/search', to: 'parks#index', as: 'search'


### PR DESCRIPTION
**ユーザーのプロフィール編集機能を実装しました**
・ヘッダーにあるプロフィール編集リンクから、プロフィール詳細(/profile)に遷移するよう実装しました
・プロフィールの編集をturbo_stream_tagを使用し、画面遷移せずに編集カードの部分のみedit.html.erbを呼び出すことで名前とメールアドレスの編集ができるよう実装しました
・Googleアカウントを連携してログインしているユーザーは、メールを静的表示にすることで、編集できないように表示内容を分岐しました

![2446132e0db3914cb4dedc2c0ba0b9d9](https://github.com/yamazaki-yuri/tokyopicnic/assets/151484437/7403240e-2509-4ace-b503-5be7f0078ef0)



Closes #14 