### PR TITLE
検索のturbo_frame修正

### DIFF
--- a/app/views/parks/_search_form.html.erb
+++ b/app/views/parks/_search_form.html.erb
@@ -1,52 +1,50 @@
-<%= turbo_frame_tag "search" do %>
-  <div class="card bg-base-100 shadow-xl mb-5 md:w-1/2" data-turbo-frame="_top">
-    <div class="card-body">
-      <div class="pb-1 text-park font-bold">
-        - 公園名で探す -
-      </div>
-      <%= search_form_for @q do |f| %>
-        <div class="pb-5 border-b-2 border-slate-200">
-          <%= f.text_field :name_cont_any, placeholder: "公園名を入力してください", class: "input input-bordered input-success w-full", style: "height: 40px;" %>
-        </div>
-        <div class="pt-5 text-park font-bold">
-          - 条件で絞り込む -
-        </div>
-        <div class="pt-2 flex justify-between flex-row">
-          <div>
-            <div class="pb-2 text-park">
-              <%= f.collection_select :fee, [["有料", "paid"], ["無料", "free"]], :last, :first, { prompt: '料金は？' }, class: "select select-success max-w-xs" %>
-            </div>
-            <div class="pb-2 text-park">
-              <%= f.collection_select :tokyo_wards_id_eq, TokyoWard.all, :id, :name, { prompt: '区を選択' }, class: "select select-success max-w-xs" %>
-            </div>
-          </div>
-          <div class="w-2/3 md:pl-3 lg:pl-0">
-            <div class="text-park">
-              <%= f.check_box :food_allowed_in, { multiple: true }, "possible", nil  %>
-              <i class="fa-solid fa-utensils">
-              <%= f.label :food_allowed_in_possible, "飲食可" %></i>
-            </div>
-            <div class="text-park">
-              <%= f.check_box :alcohol_allowed_in, { multiple: true }, "possible", nil %>
-              <i class="fa-solid fa-champagne-glasses">
-              <%= f.label :alcohol_allowed_in_possible, "お酒飲んでいい" %></i>
-            </div>
-            <div class="text-park">
-              <%= f.check_box :sheet_available_in, { multiple: true }, "possible", nil %>
-              <i class="fa-solid fa-bacon">
-              <%= f.label :sheet_available_in_possible, "シートを敷ける" %></i>
-            </div>
-            <div class="text-park">
-              <%= f.check_box :bringing_in_play_equipment_in, { multiple: true }, "possible", nil %>
-              <i class="fa-solid fa-futbol">
-              <%= f.label :bringing_in_play_equipment_in_possible, "遊具で遊んでいい" %></i>
-            </div>
-          </div>
-        </div>
-        <div class="btn btn-sm btn-secondary mt-3 w-full">
-          <%= f.submit "検索", data: { turbo_frame: "_top" } %>
-        </div>
-      <% end %>
+<div class="card bg-base-100 shadow-xl mb-5 md:w-1/2">
+  <div class="card-body">
+    <div class="pb-1 text-park font-bold">
+      - 公園名で探す -
     </div>
+    <%= search_form_for @q do |f| %>
+      <div class="pb-5 border-b-2 border-slate-200">
+        <%= f.text_field :name_cont_any, placeholder: "公園名を入力してください", class: "input input-bordered input-success w-full", style: "height: 40px;" %>
+      </div>
+      <div class="pt-5 text-park font-bold">
+        - 条件で絞り込む -
+      </div>
+      <div class="pt-2 flex justify-between flex-row">
+        <div>
+          <div class="pb-2 text-park">
+            <%= f.collection_select :fee, [["有料", "paid"], ["無料", "free"]], :last, :first, { prompt: '料金は？' }, class: "select select-success max-w-xs" %>
+          </div>
+          <div class="pb-2 text-park">
+            <%= f.collection_select :tokyo_wards_id_eq, TokyoWard.all, :id, :name, { prompt: '区を選択' }, class: "select select-success max-w-xs" %>
+          </div>
+        </div>
+        <div class="w-2/3 md:pl-3 lg:pl-0">
+          <div class="text-park">
+            <%= f.check_box :food_allowed_in, { multiple: true }, "possible", nil  %>
+            <i class="fa-solid fa-utensils">
+            <%= f.label :food_allowed_in_possible, "飲食可" %></i>
+          </div>
+          <div class="text-park">
+            <%= f.check_box :alcohol_allowed_in, { multiple: true }, "possible", nil %>
+            <i class="fa-solid fa-champagne-glasses">
+            <%= f.label :alcohol_allowed_in_possible, "お酒飲んでいい" %></i>
+          </div>
+          <div class="text-park">
+            <%= f.check_box :sheet_available_in, { multiple: true }, "possible", nil %>
+            <i class="fa-solid fa-bacon">
+            <%= f.label :sheet_available_in_possible, "シートを敷ける" %></i>
+          </div>
+          <div class="text-park">
+            <%= f.check_box :bringing_in_play_equipment_in, { multiple: true }, "possible", nil %>
+            <i class="fa-solid fa-futbol">
+            <%= f.label :bringing_in_play_equipment_in_possible, "遊具で遊んでいい" %></i>
+          </div>
+        </div>
+      </div>
+      <div class="btn btn-sm btn-secondary mt-3 w-full">
+        <%= f.submit "検索", data: { turbo_frame: "search" } %>
+      </div>
+    <% end %>
   </div>
-<% end %>
+</div>

--- a/app/views/parks/index.html.erb
+++ b/app/views/parks/index.html.erb
@@ -1,28 +1,30 @@
 <div  class="flex-grow container mx-auto px-6 py-10">
-  <%= render 'search_form' %>
-  <div class="flex justify-center items-center md:justify-between flex-col md:flex-row gap-y-8 xl:gap-x-5 lg:gap-x-5 sm:gap-x-5 px-2 pb-8 grid xl:grid-cols-4 lg:grid-cols-3 sm:grid-cols-2">
-    <% @parks.each do |park| %>
-      <div class="card bg-base-100 shadow-xl flex flex-col md:gap-x-10">
-        <figure>
-          <div>
-            <% if park.park_images.any? %>
-              <%= image_tag park.park_images.first.url.url %>
-            <% else %>
-              <%= image_tag 'default.png' %>
-            <% end %>
-          </div>
-        </figure>
-        <div class="card-body flex justify-center items-center">
-          <div class="text-park text-center ">
-            <p>-<%= "#{park.tokyo_wards.first.name}" %>-</p>
-          </div> 
-          <div class="card-title flex justify-center items-center w-full border-b-2 border-slate-200 text-park pb-2">
+  <%= turbo_frame_tag "search" do %>
+    <%= render 'search_form' %>
+    <div class="flex justify-center items-center md:justify-between flex-col md:flex-row gap-y-8 xl:gap-x-5 lg:gap-x-5 sm:gap-x-5 px-2 pb-8 grid xl:grid-cols-4 lg:grid-cols-3 sm:grid-cols-2">
+      <% @parks.each do |park| %>
+        <div class="card bg-base-100 shadow-xl flex flex-col md:gap-x-10">
+          <figure>
             <div>
-              <%= link_to "#{park.name}", park_path(park) %>
+              <% if park.park_images.any? %>
+                <%= image_tag park.park_images.first.url.url %>
+              <% else %>
+                <%= image_tag 'default.png' %>
+              <% end %>
+            </div>
+          </figure>
+          <div class="card-body flex justify-center items-center">
+            <div class="text-park text-center ">
+              <p>-<%= "#{park.tokyo_wards.first.name}" %>-</p>
+            </div> 
+            <div class="card-title flex justify-center items-center w-full border-b-2 border-slate-200 text-park pb-2">
+              <div>
+                <%= link_to "#{park.name}", park_path(park) %>
+              </div>
             </div>
           </div>
         </div>
-      </div>
-    <% end %>
-  </div>
+      <% end %>
+    </div>
+  <% end %>
 </div>


### PR DESCRIPTION
#101 で導入した検索画面のturbo_frame_tagが機能しておらず、修正しました。
・turbo_frame_tagで囲んでいた要素が検索フォームだけだったところを、検索フォームに加えて公園カードも含む部分を囲うように修正しました。
・検索ボタンに設定していたidが要素のidと一致するよう修正しました

下記のように、ページ全体がレンダリングされることなく、検索結果のみがレンダリングされるようになりました。
![4a99efe0baa9a91502fdfb3bd52fbd61](https://github.com/yamazaki-yuri/tokyopicnic/assets/151484437/f839f0db-03ae-4bfc-b6a0-6bb5e5c5a96c)
