### PR TITLE
ParkImageとParkReportImageの本番環境での保存先をS3に変更

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,6 +21,8 @@ FROM base as build
 RUN apt-get update -qq && \
     apt-get install --no-install-recommends -y build-essential curl git libpq-dev libvips node-gyp pkg-config python-is-python3
 
+RUN apt-get install -y imagemagick
+
 # Install JavaScript dependencies
 ARG NODE_VERSION=20.12.2
 ARG YARN_VERSION=1.22.19

--- a/app/uploaders/park_image_uploader.rb
+++ b/app/uploaders/park_image_uploader.rb
@@ -4,8 +4,12 @@ class ParkImageUploader < CarrierWave::Uploader::Base
   include CarrierWave::MiniMagick
 
   # Choose what kind of storage to use for this uploader:
-  storage :file
-  # storage :fog
+  if Rails.env.production?
+    storage :fog
+  else
+    storage :file
+  end
+
   def default_url(*args)
     ActionController::Base.helpers.asset_path("fallback/" + [version_name, "default.png"].compact.join('_'))
   end

--- a/app/uploaders/report_image_uploader.rb
+++ b/app/uploaders/report_image_uploader.rb
@@ -4,8 +4,11 @@ class ReportImageUploader < CarrierWave::Uploader::Base
   include CarrierWave::MiniMagick
 
   # Choose what kind of storage to use for this uploader:
-  storage :file
-  # storage :fog
+  if Rails.env.production?
+    storage :fog
+  else
+    storage :file
+  end
 
   # Override the directory where uploaded files will be stored.
   # This is a sensible default for uploaders that are meant to be mounted:


### PR DESCRIPTION
ParkImageとParkReportImageについて、本番環境で画像を保存できるように実装しました。
・park_image_uploader.rb
・report_image_uploader.rb
それぞれ、本番環境での画像の保存先を:fogに指定しました。

ローカル環境で試しに画像を投稿したところ、正常にAWSのS3に画像が保存できました。