### PR TITLE
Feature add catchphrase

### DIFF
--- a/app/models/park.rb
+++ b/app/models/park.rb
@@ -1,8 +1,8 @@
 class Park < ApplicationRecord
-  has_many :park_reports
-  has_many :park_tokyo_wards
+  has_many :park_reports, dependent: :destroy
+  has_many :park_tokyo_wards, dependent: :destroy
   has_many :tokyo_wards, through: :park_tokyo_wards
-  has_many :park_images
+  has_many :park_images, dependent: :destroy
   has_many :bookmarks, dependent: :destroy
 
   validates :name, presence: true

--- a/app/views/park_reports/new.html.erb
+++ b/app/views/park_reports/new.html.erb
@@ -1,5 +1,5 @@
 <% content_for(:title, t('.title')) %>
-<div class="flex-grow container mx-auto px-6 py-10">
+<div class="flex-grow container mx-auto px-6 py-5">
   <div class="flex justify-center items-center">
     <div class="text-2xl md:text-3xl lg:text-4xl text-park text-center font-bold pb-5 px-8 border-b-2 border-park">
     新規投稿

--- a/app/views/parks/index.html.erb
+++ b/app/views/parks/index.html.erb
@@ -1,4 +1,4 @@
-<div class="flex-grow container mx-auto px-6 py-10">
+<div class="flex-grow container mx-auto px-6 py-5">
   <div class="flex justify-center items-center">
     <div class="text-2xl md:text-3xl lg:text-4xl text-park text-center font-bold pb-5 px-8 border-b-2 border-park">
       公園を見つける

--- a/app/views/parks/show.html.erb
+++ b/app/views/parks/show.html.erb
@@ -1,10 +1,14 @@
-<div class="flex-grow container mx-auto px-6 py-10">
+<div class="flex-grow container mx-auto px-6 py-5">
   <div class="text-center">
+    <% if @park.catchphrase.present? %>
+      <p class="text-park text-xl pb-5"><%= "#{@park.catchphrase}" %></p>
+    <% else %>
+      <p class="text-park pb-5">キャッチフレーズ募集中<p>
+    <% end %>
     <p class="text-park">- <%=  @tokyo_ward.name %> -<p>
-    <div class="flex justify-center items-center">
-      <p class="text-park text-3xl md:text-4xl py-3 px-8 border-b-2 border-park w-auto"><%=  @park.name %><p>
+    <div class="flex justify-center items-center md:pb-20">
+      <p class="text-park text-3xl md:text-4xl py-5 px-8 border-b-2 border-park w-auto"><%=  @park.name %><p>
     </div>
-    <p class="text-park py-5 md:pb-20">キャッチフレーズ</p>
   </div>
 
   <div class="flex justify-center items-center md:justify-between flex-col md:flex-row md:gap-x-10 px-3">
@@ -56,7 +60,7 @@
           <p class="pl-10"><%= @park.display_permission_value(:bringing_in_play_equipment) %></p>
         </div>
         <div class="flex flex-col lg:flex-row justify-between px-3 border-b-2 border-slate-200 pb-1 text-park">
-          <p class="pl-5"><i class="fa-solid fa-heart pb-5"></i>おすすめの理由</p>
+          <p class="pl-5"><i class="fa-solid fa-heart pb-3"></i>おすすめの理由</p>
           <p class="pl-10"><%= @park.recommended_points %></p>
         </div>
         <% if @park_images.empty? %>

--- a/app/views/parks/show.html.erb
+++ b/app/views/parks/show.html.erb
@@ -52,12 +52,12 @@
           <p class="pl-10"><%= @park.display_permission_value(:sheet_available) %></p>
         </div>
         <div class="flex justify-between border-b-2 border-slate-200 pb-1 text-park">
-          <p class="w-1/3 pl-5"><i class="fa-regular fa-futbol pr-3"></i>遊具の持ち込み</p>
+          <p class="w-1/3 pl-8"><i class="fa-regular fa-futbol pr-3"></i>持ち込み遊具</p>
           <p class="pl-10"><%= @park.display_permission_value(:bringing_in_play_equipment) %></p>
         </div>
-        <div class="flex justify-between border-b-2 border-slate-200 pb-1 text-park">
-          <p class="w-1/3 pl-5"><i class="fa-solid fa-heart pr-3"></i>おすすめの理由</p>
-          <p class="pl-10">-</p>
+        <div class="flex flex-col lg:flex-row justify-between px-3 border-b-2 border-slate-200 pb-1 text-park">
+          <p class="pl-5"><i class="fa-solid fa-heart pb-5"></i>おすすめの理由</p>
+          <p class="pl-10"><%= @park.recommended_points %></p>
         </div>
         <% if @park_images.empty? %>
           <div class="text-park text-center">

--- a/app/views/parks/show.html.erb
+++ b/app/views/parks/show.html.erb
@@ -22,7 +22,11 @@
     <div class="card-body bg-white rounded-md w-full h-auto md:h-full object-cover">
         <h2 class="card-title pb-2 pl-3 border-b-2 border-slate-200 text-park">
           公式サイト
-          <%= link_to 'こちら', "#{@park.website_url}", class: "badge badge border-b-2 border-park text-park" %>
+          <% if @park.website_url.present? %>
+            <%= link_to 'こちら', "#{@park.website_url}", class: "badge badge border-b-2 border-park text-park" %>
+          <% else %>
+            <p class="badge badge border-b-2 border-park text-park">なし<p>
+          <% end %>
           <% if user_signed_in? %>
             <%= render 'bookmark_button', { park: @park } %>
           <% else %>

--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -1,4 +1,4 @@
-<div class="flex-grow container mx-auto px-6 py-10">
+<div class="flex-grow container mx-auto px-6 py-5">
   <div class="flex justify-center items-center">
     <div class="text-2xl md:text-3xl lg:text-4xl text-park text-center font-bold pb-5 px-8 border-b-2 border-park">
       <%= current_user.name %>さんのプロフィール

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -1,7 +1,7 @@
 <footer class="flex w-full footer p-3 bg-lime-800 text-neutral-content">
   <nav class="p-3">
     <h6 class="footer-title text-slate-100">Services</h6> 
-    <%= link_to 'ランダム選定', '#', class: "link link-hover text-slate-100" %>
+    <%= link_to 'ランダム選定', root_path, class: "link link-hover text-slate-100" %>
     <%= link_to '公園検索', search_path, class: "link link-hover text-slate-100" %>
     <%= link_to '新規投稿', new_park_report_path, class: "link link-hover text-slate-100" %>
   </nav> 

--- a/app/views/tops/index.html.erb
+++ b/app/views/tops/index.html.erb
@@ -1,17 +1,22 @@
 <% content_for(:title, t('.title')) %>
 <%= stylesheet_link_tag 'top' %>
 <div class="main-container">
-  <h1 class="text-center font-bold text-4xl pt-10">東京にも、緑はある。</h1>
+  <h1 class="text-center font-bold text-4xl pt-10" style="padding-left: 0.5em;">東京にも、緑はある。</h1>
+  <p class="text-center pt-5">23区の公園で新たな発見を</p>
   <div class="flex justify-center items-center pt-10">
   <%= turbo_frame_tag "park_info_frame" do %>
     <button class="btn custom-btn" onclick="random_park_modal.showModal()">行ったことある？？</button>
     <dialog id="random_park_modal" class="modal">
       <div class="modal-box">
         <div class="pb-8">
-          <div class="justify-center text-center pb-5">
-            <p class="text-park">- <%= @park_tokyo_ward.name %> -</p>
-            <p class="text-park py-2">キャッチコピー</p>
-            <div class="text-park font-bold text-xl py-2 mx-20 border-b-2 border-park">
+          <div class="justify-center text-center pb-5 px-10">
+            <% if @park.catchphrase.present? %>
+              <p class="text-park font-bold text-2xl py-2 pb-3 border-b-2 border-park"><%= "#{@park.catchphrase}" %></p>
+            <% else %>
+              <p class="text-park py-2">キャッチフレーズ募集中<p>
+            <% end %>
+            <p class="text-park pt-3">- <%= @park_tokyo_ward.name %> -</p>
+            <div class="text-park font-bold text-xl">
               <%= @park.name %>
             </div>
           </div>

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -1,4 +1,4 @@
-<div class="flex-grow container mx-auto px-6 py-10">
+<div class="flex-grow container mx-auto px-6 py-5">
   <div class="flex justify-center items-center">
     <div class="text-2xl md:text-3xl lg:text-4xl text-park text-center font-bold pb-5 px-8 border-b-2 border-park">
       <%= current_user.name %>さんのページ

--- a/app/views/users/registrations/new.html.erb
+++ b/app/views/users/registrations/new.html.erb
@@ -1,7 +1,7 @@
 <% content_for(:title, t('.title')) %>
-<div class="flex-grow container flex justify-center items-center flex-col mx-auto px-6 py-10">
+<div class="flex-grow container flex justify-center items-center flex-col mx-auto px-6 py-5">
   <div class="flex justify-center items-center flex-col">
-    <div class="px-10 py-10 sm:mx-40 xl:mx-96", style="width:400px">
+    <div class="px-10 py-5 sm:mx-40 xl:mx-96", style="width:400px">
       <%= form_with scope: resource, as: resource_name, url: registration_path(resource_name), local: true do |f| %>
         <div class="block text-2xl font-bold text-center text-park">
           ユーザー登録
@@ -38,7 +38,7 @@
         </div>
         
         <div class="mt-12">
-          <button class="group relative w-full flex btn btn-primary text-park">
+          <button class="group relative w-full flex btn btn-primary">
             <%= f.submit "登録" %>
           </button>
         </div>

--- a/app/views/users/sessions/new.html.erb
+++ b/app/views/users/sessions/new.html.erb
@@ -1,7 +1,7 @@
 <% content_for(:title, t('.title')) %>
-<div class="flex-grow container mx-auto px-6 py-10">
+<div class="flex-grow container mx-auto px-6 py-5">
   <div class="flex justify-center items-center flex-col">
-    <div class="px-10 py-10 sm:mx-40 xl:mx-96", style="width:400px">
+    <div class="px-10 py-5 sm:mx-40 xl:mx-96", style="width:400px">
       <div class="block text-2xl font-bold text-center text-park">
         ログイン
       </div>
@@ -14,7 +14,7 @@
           <%= f.password_field :password, class: "py-3 px-5 mt-1 block w-full placeholder-gray-400 border-2 border-primary rounded-lg", placeholder: "パスワードを入力" %>
         </div>
         <div class="mt-8">
-          <button type="submit" class="btn btn-primary text-park w-full">
+          <button type="submit" class="btn btn-primary w-full">
             <%= f.submit "ログイン" %>
           </button>
         </div>
@@ -25,7 +25,7 @@
         <div class="mt-8 flex flex-col w-full">
           <%= render 'google_signin_button' %>
         </div>
-        <div class="mt-8 text-center text-park">
+        <div class="mt-8 pb-8 text-center text-park">
           <%= link_to 'はじめての方はこちら', new_user_registration_path %>
         </div>
       </div>

--- a/db/migrate/20240522031523_add_catchphrase_and_recommended_points_to_parks.rb
+++ b/db/migrate/20240522031523_add_catchphrase_and_recommended_points_to_parks.rb
@@ -1,0 +1,6 @@
+class AddCatchphraseAndRecommendedPointsToParks < ActiveRecord::Migration[7.1]
+  def change
+    add_column :parks, :catchphrase, :string
+    add_column :parks, :recommended_points, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_05_18_020234) do
+ActiveRecord::Schema[7.1].define(version: 2024_05_22_031523) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -67,6 +67,8 @@ ActiveRecord::Schema[7.1].define(version: 2024_05_18_020234) do
     t.integer "alcohol_allowed", default: 2
     t.integer "sheet_available", default: 2
     t.integer "bringing_in_play_equipment", default: 2
+    t.string "catchphrase"
+    t.string "recommended_points"
     t.index ["googlemaps_place_id"], name: "index_parks_on_googlemaps_place_id", unique: true
   end
 


### PR DESCRIPTION
公園テーブルに、キャッチフレーズとおすすめポイントのカラムを追加しました。

公園詳細ページには、以下のように実装しました。
・ページのトップにある公園名の上にキャッチフレーズがデータにあれば表示し、なければキャッチフレーズ募集中と表示されるように実装しました。
・公園情報のおすすめポイントがデータにあれば表示し、なければ空欄になるように実装しました。

トップページのランダムボタンを押した際の公園カードには、以下のように実装しました。
・トップにある公園名の上にキャッチフレーズがデータにあれば表示し、なければキャッチフレーズ募集中と表示されるように実装しました。
・公園名よりもキャッチフレーズが目立つよう、下線をキャッチフレーズに引くように変更しました。

![516619e3107f018dc266eea21da03250](https://github.com/yamazaki-yuri/tokyopicnic/assets/151484437/b2b869d8-dfcb-4e09-8eb1-aff8c4d6e274)
![c74550c4c6201f3691966bfa557b556d](https://github.com/yamazaki-yuri/tokyopicnic/assets/151484437/3a7de346-1fab-41c3-bd77-f4ef378ed5d6)

Closes #115 