### PR TITLE
新規投稿フォームの修正

### DIFF
--- a/app/views/park_reports/_edit.html.erb
+++ b/app/views/park_reports/_edit.html.erb
@@ -4,7 +4,7 @@
     <%= f.date_field :date, class: "block shadow rounded-md border border-gray-200 outline-none px-3 py-2 mt-2 w-full" %>
   </div>
   <div class="mt-8 mb-8 flex flex-col px-5">
-    <%= f.label :title, "公演をひとことで" %>
+    <%= f.label :title, "公園をひとことで" %>
     <%= f.text_field :title, placeholder: 'どんな公園？', class: "textarea textarea-primary" %>
   </div>
   <div class="mt-8 mb-8 flex flex-col px-5">

--- a/app/views/park_reports/_edit.html.erb
+++ b/app/views/park_reports/_edit.html.erb
@@ -4,12 +4,12 @@
     <%= f.date_field :date, class: "block shadow rounded-md border border-gray-200 outline-none px-3 py-2 mt-2 w-full" %>
   </div>
   <div class="mt-8 mb-8 flex flex-col px-5">
-    <%= f.label :title, "タイトル" %>
-    <%= f.text_field :title, placeholder: '思ったことを自由に記入', class: "textarea textarea-primary" %>
+    <%= f.label :title, "公演をひとことで" %>
+    <%= f.text_field :title, placeholder: 'どんな公園？', class: "textarea textarea-primary" %>
   </div>
   <div class="mt-8 mb-8 flex flex-col px-5">
-    <%= f.label :comment, "ひとこと" %>
-    <%= f.text_field :comment, placeholder: '思ったことを自由に記入', class: "textarea textarea-primary" %>
+    <%= f.label :comment, "思い出" %>
+    <%= f.text_area :comment, placeholder: '自由に記入して思い出を記録しよう', class: "textarea textarea-primary" %>
   </div>
   <div class="btn btn-ghost rounded-btn hover:bg-slate-200 text-park mt-5 w-full">
     <%= f.submit '登録する' %>

--- a/app/views/park_reports/new.html.erb
+++ b/app/views/park_reports/new.html.erb
@@ -6,7 +6,7 @@
     </div>
   </div>
   <div class="flex justify-center items-center">
-    <div class="card bg-base-100 shadow-xl mt-8 flex flex-col w-96">
+    <div class="card bg-base-100 text-park shadow-xl mt-8 flex flex-col w-96">
       <figure class="flex">
         <%= form_with(model: @park_report, url: park_reports_path, local: true) do |f| %>
           <%= render 'shared/error_messages', object: @park_report %>
@@ -18,22 +18,22 @@
             <%= f.collection_select :tokyo_ward_id, TokyoWard.all,  :id, :name, {include_blank: "区を選択"}, {class: "select select-primary max-w-xs"} %>
           </div>
           <div class="my-5 flex flex-col px-5">
-            <%= f.label :date, "日付(任意)" %>
+            <%= f.label :date, "日付" %>
             <%= f.date_field :date, class: "block shadow rounded-md border border-gray-200 outline-none px-3 py-2 mt-2 w-full" %>
           </div>
             <%= f.fields_for :report_images do |report_image| %>
               <div class="field mt-8 flex flex-col pl-5">
                 <%= report_image.label :url, "写真" %>
-                <%= report_image.file_field :url %>
+                <%= report_image.file_field :url, class: "file-input file-input-bordered file-input w-full max-w-xs", style: "max-height: 40px;"%>
               </div>
             <% end %>
           <div class="mt-8 mb-8 flex flex-col px-5">
-            <%= f.label :title, "タイトル(必須)" %>
+            <%= f.label :title, "公園をひとことで(⚠︎必須)" %>
             <%= f.text_field :title, placeholder: 'どんな公園だった？', class: "textarea textarea-primary" %>
           </div>
           <div class="mt-8 mb-8 flex flex-col px-5">
-            <%= f.label :comment, "ひとこと" %>
-            <%= f.text_field :comment, placeholder: '思ったことを自由に記入', class: "textarea textarea-primary" %>
+            <%= f.label :comment, "思い出" %>
+            <%= f.text_area :comment, placeholder: '自由に記入して思い出を残そう', class: "textarea textarea-primary" %>
           </div>
           <div class="my-5 flex flex-col px-5">
             <button class="btn btn-primary">


### PR DESCRIPTION
公園の新規投稿と、投稿修正のフォームのうち、思い出を記入するフィールドがtext_fieldになっていたのを、text_areaに修正し、改行できるようにしました。

Closes #117 