### PR TITLE
飲酒の表示を変更

### DIFF
--- a/app/models/park.rb
+++ b/app/models/park.rb
@@ -7,13 +7,15 @@ class Park < ApplicationRecord
 
   validates :name, presence: true
 
+  enum alcohol_allowed: { within_common_sense: 0, impossible: 1, unspecified: 2 }, _prefix: true
   enum food_allowed: { possible: 0, impossible: 1, unspecified: 2 }, _prefix: true
-  enum alcohol_allowed: { possible: 0, impossible: 1, unspecified: 2 }, _prefix: true
   enum sheet_available: { possible: 0, impossible: 1, unspecified: 2 }, _prefix: true
   enum bringing_in_play_equipment: { possible: 0, impossible: 1, unspecified: 2 }, _prefix: true
+  enum dog_run: { possible: 0, impossible: 1, unspecified: 2 }, _prefix: true
+  enum bbq_area: { possible: 0, impossible: 1, unspecified: 2 }, _prefix: true
 
   def self.ransackable_attributes(auth_object = nil)
-    ["food_allowed", "alcohol_allowed", "sheet_available", "bringing_in_play_equipment", "fee",  "name", "updated_at", "created_at"]
+    ["food_allowed", "alcohol_allowed", "sheet_available", "bringing_in_play_equipment", "fee",  "name", "dog_run", "bbq_area", "updated_at", "created_at"]
   end
 
   def self.ransackable_associations(auth_object = nil)
@@ -28,6 +30,8 @@ class Park < ApplicationRecord
       '×'
     when 'unspecified'
       '-'
+    when 'within_common_sense'
+      '△'
     end
   end
 end

--- a/app/servise/google_places_service.rb
+++ b/app/servise/google_places_service.rb
@@ -13,7 +13,7 @@ class GooglePlacesService
       query: {
         location: location,
         keyword: keyword,
-        radius: 3000,
+        radius: 5000,
         type: 'park',
         key: @api_key,
         language: 'ja'

--- a/app/views/parks/_search_form.html.erb
+++ b/app/views/parks/_search_form.html.erb
@@ -22,14 +22,14 @@
           </div>
           <div class="w-2/3">
             <div class="text-park">
+              <%= f.check_box :alcohol_allowed_in, { multiple: true }, "within_common_sense", nil %>
+              <i class="fa-solid fa-champagne-glasses">
+              <%= f.label :alcohol_allowed_in_within_common_sense, "飲酒禁止を除く" %></i>
+            </div>
+            <div class="text-park">
               <%= f.check_box :food_allowed_in, { multiple: true }, "possible", nil  %>
               <i class="fa-solid fa-utensils">
               <%= f.label :food_allowed_in_possible, "飲食 OK" %></i>
-            </div>
-            <div class="text-park">
-              <%= f.check_box :alcohol_allowed_in, { multiple: true }, "possible", nil %>
-              <i class="fa-solid fa-champagne-glasses">
-              <%= f.label :alcohol_allowed_in_possible, "お酒 OK" %></i>
             </div>
             <div class="text-park">
               <%= f.check_box :sheet_available_in, { multiple: true }, "possible", nil %>
@@ -40,6 +40,16 @@
               <%= f.check_box :bringing_in_play_equipment_in, { multiple: true }, "possible", nil %>
               <i class="fa-solid fa-futbol">
               <%= f.label :bringing_in_play_equipment_in_possible, "遊具 OK" %></i>
+            </div>
+            <div class="text-park">
+              <%= f.check_box :bbq_area_in, { multiple: true }, "possible", nil %>
+              <i class="fa-solid fa-fire-burner">
+              <%= f.label :bbq_area_in_possible, "BQQ場有" %></i>
+            </div>
+            <div class="text-park">
+              <%= f.check_box :dog_run_in, { multiple: true }, "possible", nil %>
+              <i class="fa-solid fa-dog">
+              <%= f.label :dog_run_in_possible, "ドッグラン有" %></i>
             </div>
           </div>
         </div>

--- a/app/views/parks/show.html.erb
+++ b/app/views/parks/show.html.erb
@@ -81,6 +81,13 @@
           </dialog>
       </div>
     </div>
+    <p class="text-park text-sm pt-5">※飲酒は、禁止されている公園以外△とさせていただいております。他のお客様のご迷惑にならぬよう、節度を守って楽しみましょう。詳しくは
+      <% if @park.website_url.present? %>
+        <%= link_to '公式サイト', "#{@park.website_url}", class: "font-bold" %>
+      <% end %>
+      をご確認ください。
+    </p>
+
 
     <div class="flex justify-center items-center flex-col py-10">
       <div style="width: 90%; height: 300px;">

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -6,7 +6,7 @@
   </div>
 
   <div class="py-5">
-    <p class="text-xl md:text-2xl text-park font-bold py-5 text-center">- 私の公園日記 -</p>
+    <p class="text-xl md:text-2xl text-park font-bold py-5 text-center">- わたしの公園日記 -</p>
   </div>
   <div class="px-8 flex justify-center items-center md:justify-between flex-col md:flex-row gap-y-8 xl:gap-x-5 lg:gap-x-5 sm:gap-x-5 pb-8  grid xl:grid-cols-4 lg:grid-cols-3  sm:grid-cols-2">
     <% @park_reports.each do |park_report| %>

--- a/db/migrate/20240523105943_add_dog_run_and_bbq_area_to_parks.rb
+++ b/db/migrate/20240523105943_add_dog_run_and_bbq_area_to_parks.rb
@@ -1,0 +1,6 @@
+class AddDogRunAndBbqAreaToParks < ActiveRecord::Migration[7.1]
+  def change
+    add_column :parks, :dog_run, :integer, default: 2
+    add_column :parks, :bbq_area, :integer, default: 2
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_05_23_050957) do
+ActiveRecord::Schema[7.1].define(version: 2024_05_23_105943) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -69,6 +69,8 @@ ActiveRecord::Schema[7.1].define(version: 2024_05_23_050957) do
     t.integer "bringing_in_play_equipment", default: 2
     t.string "catchphrase"
     t.string "recommended_points"
+    t.integer "dog_run", default: 2
+    t.integer "bbq_area", default: 2
     t.index ["googlemaps_place_id"], name: "index_parks_on_googlemaps_place_id", unique: true
   end
 


### PR DESCRIPTION
公園テーブルに新たに以下のカラムを追加しました。
・dog_run : integer
・bbq_area : integer
公園検索時の絞り込み機能に、ドッグランがあるか・BQQ会場があるかを追加しました。

公園詳細情報として、飲酒の項目において◯を削除し、△、×、-の3種類の表示に変更しました。
・飲酒を△表示にするにあたり、注意書きを追加しました。

Closes #119 