### PR TITLE
公園検索画面にピンの刺さったマップを表示する

### DIFF
--- a/app/controllers/park_reports_controller.rb
+++ b/app/controllers/park_reports_controller.rb
@@ -116,10 +116,12 @@ class ParkReportsController < ApplicationController
         return
       end
     place_id = park_info['place_id']
+    park_lat = park_info['geometry']['location']['lat']
+    park_lng = park_info['geometry']['location']['lng']
     web_response = google_places_service.get_website(place_id)
     website = web_response['result']['website']
   
-    @park = Park.create(name: @park_name, googlemaps_place_id: place_id, website_url: website)
+    @park = Park.create(name: @park_name, googlemaps_place_id: place_id, website_url: website, latitude: park_lat, longitude: park_lng)
     @park.tokyo_wards << @tokyo_ward
   end
 end

--- a/app/controllers/parks_controller.rb
+++ b/app/controllers/parks_controller.rb
@@ -27,6 +27,7 @@ class ParksController < ApplicationController
   def park_to_hash(park)
     { 
       id: park.id,
+      tokyo_ward_id: park.tokyo_wards.first.id,
       name: park.name,
       lat: park.latitude,
       lng: park.longitude

--- a/app/controllers/parks_controller.rb
+++ b/app/controllers/parks_controller.rb
@@ -9,6 +9,7 @@ class ParksController < ApplicationController
       end
     else
       @parks = @q.result(distinct: true).includes(:park_images, park_tokyo_wards: :tokyo_ward)
+      @parks_json = @parks.map { |o| park_to_hash(o) }.to_json
       @count = @parks.count
     end
   end
@@ -19,5 +20,16 @@ class ParksController < ApplicationController
     @park_images = @park.park_images
     @tokyo_ward = @park.tokyo_wards.first
     @park_reports = @park.park_reports.includes([:report_images, :user])
+  end
+
+  private
+
+  def park_to_hash(park)
+    { 
+      id: park.id,
+      name: park.name,
+      lat: park.latitude,
+      lng: park.longitude
+    }
   end
 end

--- a/app/javascript/controllers/google_map/application_controller.js
+++ b/app/javascript/controllers/google_map/application_controller.js
@@ -1,0 +1,12 @@
+import { Controller } from "@hotwired/stimulus"
+import { Loader } from "@googlemaps/js-api-loader"
+
+// Connects to data-controller="google-map--application"
+export default class extends Controller {
+  setLoader() {
+    return new Loader({
+      apiKey: window.ENV.GOOGLE_API_KEY,
+      version: "weekly",
+    });
+  }
+}

--- a/app/javascript/controllers/google_map/index_controller.js
+++ b/app/javascript/controllers/google_map/index_controller.js
@@ -1,0 +1,100 @@
+import ApplicationController from "./application_controller";
+
+let map;
+let markers = [];
+let infoWindows = [];
+
+// Connects to data-controller="google-map--index"
+export default class extends ApplicationController {
+  //デフォルトの地図の中心地を設定
+  static values = {
+    location: {
+      lat: 35.6855322796429,
+      lng: 139.75277781477016
+    },
+    zoom: 11,
+    parks: []
+  }
+  static targets = ['map']
+
+  connect() {
+    this.setParks();
+    this.initMapWithUserLocation();
+  }
+
+  initMapWithUserLocation() {
+    const loader = this.setLoader();
+    loader.load().then(async () => {
+      const { Map } = await google.maps.importLibrary("maps");
+
+      if (navigator.geolocation) {
+        navigator.geolocation.getCurrentPosition(
+          (position) => {
+            const userLocation = {
+              lat: position.coords.latitude,
+              lng: position.coords.longitude
+            };
+            this.createMap(userLocation);  // 現在地を中心に地図を作成
+          },
+          () => {
+            console.warn("Geolocation failed or is not available.");
+            this.createMap(this.locationValue);  // 現在地の取得に失敗した場合はデフォルトの中心地
+          }
+        );
+      } else {
+        console.warn("Geolocation is not supported by this browser.");
+        this.createMap(this.locationValue);  // Geolocationがサポートされていない場合はデフォルトの中心地
+      }
+    });
+  }
+
+  createMap(center) {
+    map = new google.maps.Map(this.mapTarget, {
+      center: center,
+      zoom: this.zoomValue,
+    });
+    this.addMarkersToMap();
+  }
+
+  addMarkersToMap() {
+    this.parksValue.forEach((o, i) => {
+      this.addMarkerToMarkers(o);
+      this.addInfoWindowToInfoWindows(o);
+      this.addEventToMarker(i);
+    });
+  }
+
+  addMarkerToMarkers(o) {
+    const marker = new google.maps.Marker({
+      position: { lat: o.lat, lng: o.lng },
+      map,
+      name: o.name
+    });
+    markers.push(marker);
+  }
+
+  addInfoWindowToInfoWindows(o) {
+    const infoWindow = new google.maps.InfoWindow({
+      content: `
+          <p>${o.name}</p><br>
+          <a href="/parks/${o.id}" data-turbolinks="true">
+            詳細を見る
+          </a><br>
+          <a href="/park_reports/new" data-turbolinks="true" data-park-name="${o.name}">
+            この公園の投稿をする
+          </a>
+        `
+    });
+    infoWindows.push(infoWindow);
+  }
+
+  addEventToMarker(i) {
+    markers[i].addListener('click', () => {
+      infoWindows[i].open(map, markers[i]);
+    });
+  }
+
+  setParks() {
+    this.parksValue = JSON.parse(this.mapTarget.dataset.json);
+  }
+}

--- a/app/javascript/controllers/google_map/index_controller.js
+++ b/app/javascript/controllers/google_map/index_controller.js
@@ -84,7 +84,7 @@ export default class extends ApplicationController {
         <a href="/parks/${o.id}" data-turbo-frame="false">
           詳細を見る
         </a><br>
-        <a href="/park_reports/new?park_name=${encodeURIComponent(o.name)}" data-turbo-frame="false">
+        <a href="/park_reports/new?park_name=${encodeURIComponent(o.name)}&tokyo_ward_id=${encodeURIComponent(o.tokyo_ward_id)}" data-turbo-frame="true">
           この公園の投稿をする
         </a>
       `

--- a/app/javascript/controllers/google_map/index_controller.js
+++ b/app/javascript/controllers/google_map/index_controller.js
@@ -6,6 +6,7 @@ let infoWindows = [];
 
 // Connects to data-controller="google-map--index"
 export default class extends ApplicationController {
+  //地図の初期値(中心地は皇居に設定)
   static values = {
     location: {
       lat: 35.6855322796429,
@@ -16,6 +17,7 @@ export default class extends ApplicationController {
   }
   static targets = ['map']
 
+  //HTMLのmap要素に接続された時に実行
   connect() {
     this.setParks();
     this.initMapWithUserLocation();
@@ -23,7 +25,7 @@ export default class extends ApplicationController {
 
   initMapWithUserLocation() {
     const loader = this.setLoader();
-    loader.load().then(async () => {
+    loader.importLibrary("marker").then(async () => {
       const { Map } = await google.maps.importLibrary("maps");
 
       if (navigator.geolocation) {
@@ -58,6 +60,7 @@ export default class extends ApplicationController {
     });
   }
 
+  //公園の情報を基に地図上にマーカーと情報ウィンドウを追加
   addMarkersToMap() {
     markers = [];
     infoWindows = [];
@@ -68,6 +71,7 @@ export default class extends ApplicationController {
     });
   }
 
+  //各公園の位置にマーカーを作成
   addMarkerToMarkers(o) {
     const marker = new google.maps.Marker({
       position: { lat: o.lat, lng: o.lng },
@@ -77,6 +81,7 @@ export default class extends ApplicationController {
     markers.push(marker);
   }
 
+  //マーカーをクリックした時に表示される情報ウィンドウの内容
   addInfoWindowToInfoWindows(o) {
     const infoWindow = new google.maps.InfoWindow({
       content: `
@@ -94,6 +99,7 @@ export default class extends ApplicationController {
     infoWindows.push(infoWindow);
   }
 
+  //マーカーがクリックされた時に情報ウィンドウを表示するイベントリスナー
   addEventToMarker(i) {
     markers[i].addListener('click', () => {
       infoWindows[i].open(map, markers[i]);

--- a/app/javascript/controllers/google_map/index_controller.js
+++ b/app/javascript/controllers/google_map/index_controller.js
@@ -80,13 +80,15 @@ export default class extends ApplicationController {
   addInfoWindowToInfoWindows(o) {
     const infoWindow = new google.maps.InfoWindow({
       content: `
-        <p>${o.name}</p><br>
-        <a href="/parks/${o.id}" data-turbo-frame="false">
+        <p class="text-park font-bold text-center text-lg">- ${o.name} -</p><br>
+        <a href="/parks/${o.id}" data-turbo-frame="false" class="btn me-2 w-full hover:bg-slate-200 rounded-lg px-2 py-1 text-park">
           詳細を見る
         </a><br>
-        <a href="/park_reports/new?park_name=${encodeURIComponent(o.name)}&tokyo_ward_id=${encodeURIComponent(o.tokyo_ward_id)}" data-turbo-frame="true">
-          この公園の投稿をする
-        </a>
+        <br>
+        <a href="/park_reports/new?park_name=${encodeURIComponent(o.name)}&tokyo_ward_id=${encodeURIComponent(o.tokyo_ward_id)}" data-turbo-frame="true" class="btn me-2 w-full hover:bg-slate-200 rounded-lg px-2 py-1 text-park">
+          この公園の日記を投稿する
+        </a><br>
+        <br>
       `
     });
     infoWindows.push(infoWindow);

--- a/app/javascript/controllers/google_map/index_controller.js
+++ b/app/javascript/controllers/google_map/index_controller.js
@@ -6,7 +6,6 @@ let infoWindows = [];
 
 // Connects to data-controller="google-map--index"
 export default class extends ApplicationController {
-  //デフォルトの地図の中心地を設定
   static values = {
     location: {
       lat: 35.6855322796429,
@@ -49,14 +48,19 @@ export default class extends ApplicationController {
   }
 
   createMap(center) {
-    map = new google.maps.Map(this.mapTarget, {
-      center: center,
-      zoom: this.zoomValue,
+    const loader = this.setLoader();
+    loader.importLibrary("marker").then(() => {
+      map = new google.maps.Map(this.mapTarget, {
+        center: center,
+        zoom: this.zoomValue,
+      });
+      this.addMarkersToMap();
     });
-    this.addMarkersToMap();
   }
 
   addMarkersToMap() {
+    markers = [];
+    infoWindows = [];
     this.parksValue.forEach((o, i) => {
       this.addMarkerToMarkers(o);
       this.addInfoWindowToInfoWindows(o);
@@ -76,14 +80,14 @@ export default class extends ApplicationController {
   addInfoWindowToInfoWindows(o) {
     const infoWindow = new google.maps.InfoWindow({
       content: `
-          <p>${o.name}</p><br>
-          <a href="/parks/${o.id}" data-turbolinks="true">
-            詳細を見る
-          </a><br>
-          <a href="/park_reports/new" data-turbolinks="true" data-park-name="${o.name}">
-            この公園の投稿をする
-          </a>
-        `
+        <p>${o.name}</p><br>
+        <a href="/parks/${o.id}" data-turbo-frame="false">
+          詳細を見る
+        </a><br>
+        <a href="/park_reports/new?park_name=${encodeURIComponent(o.name)}" data-turbo-frame="false">
+          この公園の投稿をする
+        </a>
+      `
     });
     infoWindows.push(infoWindow);
   }

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -4,6 +4,12 @@
 
 import { application } from "./application"
 
+import GoogleMap__ApplicationController from "./google_map/application_controller"
+application.register("google-map--application", GoogleMap__ApplicationController)
+
+import GoogleMap__IndexController from "./google_map/index_controller"
+application.register("google-map--index", GoogleMap__IndexController)
+
 import HelloController from "./hello_controller"
 application.register("hello", HelloController)
 

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -13,6 +13,11 @@
   </head>
 
   <body class="flex flex-col min-h-screen bg-accent">
+    <script>
+      window.ENV = {
+        GOOGLE_API_KEY: "<%= ENV['GOOGLE_API_KEY'] %>"
+      };
+    </script>
     <% if user_signed_in? %>
       <%= render 'shared/header' %>
     <% else %>

--- a/app/views/parks/_search_form.html.erb
+++ b/app/views/parks/_search_form.html.erb
@@ -4,7 +4,7 @@
       - 公園名で探す -
     </div>
     <%= search_form_for @q do |f| %>
-      <div class="pb-5 border-b-2 border-slate-200">
+      <div class="pb-5 border-b-2 border-slate-200 lg:pl-5">
         <%= f.text_field :name_cont_any, placeholder: "公園名を入力してください", class: "input input-bordered input-success w-full", style: "height: 40px;" %>
       </div>
       <div class="pt-5 text-park font-bold">
@@ -12,10 +12,10 @@
       </div>
       <div class="pt-2 flex justify-between flex-row">
         <div style="margin-right: 1rem;">
-          <div class="pb-2 text-park">
+          <div class="pb-2 text-park lg:pl-5">
             <%= f.collection_select :tokyo_wards_id_eq, TokyoWard.all, :id, :name, { include_blank: '区を選択' }, class: "select select-success max-w-xs" %>
           </div>
-          <div class="pb-2 text-park">
+          <div class="pb-2 text-park lg:pl-5">
             <%= f.collection_select :fee, [["有料", "paid"], ["無料", "free"]], :last, :first, { prompt: '料金は？' }, class: "select select-success max-w-xs" %>
           </div>
         </div>
@@ -55,7 +55,7 @@
       <div class="flex justify-center mt-3">
         <div class="btn btn-sm btn-secondary mt-3">
         <i class="fa-solid fa-magnifying-glass">
-          <%= f.submit "検索する", data: { turbo_frame: "search" } %>
+          <%= f.submit "検索する" %>
         </i>
         </div>
       </div>

--- a/app/views/parks/_search_form.html.erb
+++ b/app/views/parks/_search_form.html.erb
@@ -1,66 +1,64 @@
-<div class="py-10">
-  <div class="card bg-base-100 shadow-xl mb-5 md:w-1/2">
-    <div class="card-body">
-      <div class="pb-1 text-park font-bold">
-        - 公園名で探す -
-      </div>
-      <%= search_form_for @q do |f| %>
-        <div class="pb-5 border-b-2 border-slate-200">
-          <%= f.text_field :name_cont_any, placeholder: "公園名を入力してください", class: "input input-bordered input-success w-full", style: "height: 40px;" %>
-        </div>
-        <div class="pt-5 text-park font-bold">
-          - 条件で絞り込む -
-        </div>
-        <div class="pt-2 flex justify-between flex-row">
-          <div style="margin-right: 1rem;">
-            <div class="pb-2 text-park">
-              <%= f.collection_select :tokyo_wards_id_eq, TokyoWard.all, :id, :name, { include_blank: '区を選択' }, class: "select select-success max-w-xs" %>
-            </div>
-            <div class="pb-2 text-park">
-              <%= f.collection_select :fee, [["有料", "paid"], ["無料", "free"]], :last, :first, { prompt: '料金は？' }, class: "select select-success max-w-xs" %>
-            </div>
-          </div>
-          <div class="w-2/3">
-            <div class="text-park">
-              <%= f.check_box :alcohol_allowed_in, { multiple: true }, "within_common_sense", nil %>
-              <i class="fa-solid fa-champagne-glasses">
-              <%= f.label :alcohol_allowed_in_within_common_sense, "飲酒✖️を除く" %></i>
-            </div>
-            <div class="text-park">
-              <%= f.check_box :food_allowed_in, { multiple: true }, "possible", nil  %>
-              <i class="fa-solid fa-utensils">
-              <%= f.label :food_allowed_in_possible, "飲食 OK" %></i>
-            </div>
-            <div class="text-park">
-              <%= f.check_box :sheet_available_in, { multiple: true }, "possible", nil %>
-              <i class="fa-solid fa-bacon">
-              <%= f.label :sheet_available_in_possible, "シート OK" %></i>
-            </div>
-            <div class="text-park">
-              <%= f.check_box :bringing_in_play_equipment_in, { multiple: true }, "possible", nil %>
-              <i class="fa-solid fa-futbol">
-              <%= f.label :bringing_in_play_equipment_in_possible, "遊具 OK" %></i>
-            </div>
-            <div class="text-park">
-              <%= f.check_box :bbq_area_in, { multiple: true }, "possible", nil %>
-              <i class="fa-solid fa-fire-burner">
-              <%= f.label :bbq_area_in_possible, "BBQ場有" %></i>
-            </div>
-            <div class="text-park">
-              <%= f.check_box :dog_run_in, { multiple: true }, "possible", nil %>
-              <i class="fa-solid fa-dog">
-              <%= f.label :dog_run_in_possible, "ドッグラン有" %></i>
-            </div>
-          </div>
-        </div>
-        <div class="flex justify-center mt-3">
-          <div class="btn btn-sm btn-secondary mt-3">
-          <i class="fa-solid fa-magnifying-glass">
-            <%= f.submit "検索する", data: { turbo_frame: "search" } %>
-          </i>
-          </div>
-        </div>
-      <% end %>
+<div class="card bg-base-100 shadow-xl mb-5 w-full">
+  <div class="card-body">
+    <div class="pb-1 text-park font-bold">
+      - 公園名で探す -
     </div>
+    <%= search_form_for @q do |f| %>
+      <div class="pb-5 border-b-2 border-slate-200">
+        <%= f.text_field :name_cont_any, placeholder: "公園名を入力してください", class: "input input-bordered input-success w-full", style: "height: 40px;" %>
+      </div>
+      <div class="pt-5 text-park font-bold">
+        - 条件で絞り込む -
+      </div>
+      <div class="pt-2 flex justify-between flex-row">
+        <div style="margin-right: 1rem;">
+          <div class="pb-2 text-park">
+            <%= f.collection_select :tokyo_wards_id_eq, TokyoWard.all, :id, :name, { include_blank: '区を選択' }, class: "select select-success max-w-xs" %>
+          </div>
+          <div class="pb-2 text-park">
+            <%= f.collection_select :fee, [["有料", "paid"], ["無料", "free"]], :last, :first, { prompt: '料金は？' }, class: "select select-success max-w-xs" %>
+          </div>
+        </div>
+        <div class="w-2/3">
+          <div class="text-park text-sm md:text-base">
+            <%= f.check_box :alcohol_allowed_in, { multiple: true }, "within_common_sense", nil %>
+            <i class="fa-solid fa-champagne-glasses">
+            <%= f.label :alcohol_allowed_in_within_common_sense, "飲酒✖️を除く" %></i>
+          </div>
+          <div class="text-park text-sm md:text-base">
+            <%= f.check_box :food_allowed_in, { multiple: true }, "possible", nil  %>
+            <i class="fa-solid fa-utensils">
+            <%= f.label :food_allowed_in_possible, "飲食 OK" %></i>
+          </div>
+          <div class="text-park text-sm md:text-base">
+            <%= f.check_box :sheet_available_in, { multiple: true }, "possible", nil %>
+            <i class="fa-solid fa-bacon">
+            <%= f.label :sheet_available_in_possible, "シート OK" %></i>
+          </div>
+          <div class="text-park text-sm md:text-base">
+            <%= f.check_box :bringing_in_play_equipment_in, { multiple: true }, "possible", nil %>
+            <i class="fa-solid fa-futbol">
+            <%= f.label :bringing_in_play_equipment_in_possible, "遊具 OK" %></i>
+          </div>
+          <div class="text-park text-sm md:text-base">
+            <%= f.check_box :bbq_area_in, { multiple: true }, "possible", nil %>
+            <i class="fa-solid fa-fire-burner">
+            <%= f.label :bbq_area_in_possible, "BBQ場有" %></i>
+          </div>
+          <div class="text-park text-sm md:text-base">
+            <%= f.check_box :dog_run_in, { multiple: true }, "possible", nil %>
+            <i class="fa-solid fa-dog">
+            <%= f.label :dog_run_in_possible, "ドッグラン有" %></i>
+          </div>
+        </div>
+      </div>
+      <div class="flex justify-center mt-3">
+        <div class="btn btn-sm btn-secondary mt-3">
+        <i class="fa-solid fa-magnifying-glass">
+          <%= f.submit "検索する", data: { turbo_frame: "search" } %>
+        </i>
+        </div>
+      </div>
+    <% end %>
   </div>
 </div>

--- a/app/views/parks/index.html.erb
+++ b/app/views/parks/index.html.erb
@@ -5,7 +5,16 @@
     </div>
   </div>
   <%= turbo_frame_tag "search" do %>
-  <%= render 'search_form' %>
+  <div class="flex flex-col md:flex-row pt-8 md:gap-x-5">
+    <div class="md:w-1/2 pb-5">
+      <div data-controller="google-map--index">
+        <div data-google-map--index-target="map" data-json="<%= @parks_json %>" style="height:55vh;max-width:600px;"></div>
+      </div>
+    </div>
+    <div class="md:w-1/2">
+      <%= render 'search_form' %>
+    </div>
+  </div>
   <% if params[:q].present? %>
     <p class="text-center text-park pb-5 font-semibold">- 検索結果は<%= "#{@count}" %>件です -</p>
   <% end %>

--- a/app/views/parks/index.html.erb
+++ b/app/views/parks/index.html.erb
@@ -4,7 +4,6 @@
       公園を見つける
     </div>
   </div>
-  <%= turbo_frame_tag "search" do %>
   <div class="flex flex-col md:flex-row pt-8 md:gap-x-5">
     <div class="md:w-1/2 pb-5">
       <div data-controller="google-map--index">
@@ -43,5 +42,4 @@
       <% end %>
     <% end %>
   </div>
-  <% end %>
 </div>

--- a/app/views/parks/index.html.erb
+++ b/app/views/parks/index.html.erb
@@ -5,17 +5,17 @@
     </div>
   </div>
   <div class="flex flex-col md:flex-row pt-8 md:gap-x-5">
-    <div class="md:w-1/2 pb-5">
-      <div data-controller="google-map--index">
-        <div data-google-map--index-target="map" data-json="<%= @parks_json %>" style="height:55vh;max-width:600px;"></div>
-      </div>
-    </div>
-    <div class="md:w-1/2">
+    <div class="md:w-1/2 xl:w-1/3">
       <%= render 'search_form' %>
+    </div>
+    <div class="md:w-1/2 xl:w-2/3 pb-5">
+      <div data-controller="google-map--index">
+        <div data-google-map--index-target="map" data-json="<%= @parks_json %>" style="height:55vh;max-width:800px;"></div>
+      </div>
     </div>
   </div>
   <% if params[:q].present? %>
-    <p class="text-center text-park pb-5 font-semibold">- 検索結果は<%= "#{@count}" %>件です -</p>
+    <p class="text-center text-park text-xl pb-5 font-semibold">- 検索結果は<%= "#{@count}" %>件です -</p>
   <% end %>
   <div class="flex justify-center items-center md:justify-between flex-col md:flex-row gap-y-8 xl:gap-x-5 lg:gap-x-5 sm:gap-x-5 px-2 pb-8 grid xl:grid-cols-4 lg:grid-cols-3 sm:grid-cols-2">
     <% @parks.each do |park| %>

--- a/db/migrate/20240529041315_add_latitude_and_longitude_to_parks.rb
+++ b/db/migrate/20240529041315_add_latitude_and_longitude_to_parks.rb
@@ -1,0 +1,6 @@
+class AddLatitudeAndLongitudeToParks < ActiveRecord::Migration[7.1]
+  def change
+    add_column :parks, :latitude, :float
+    add_column :parks, :longitude, :float
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_05_23_105943) do
+ActiveRecord::Schema[7.1].define(version: 2024_05_29_041315) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -71,6 +71,8 @@ ActiveRecord::Schema[7.1].define(version: 2024_05_23_105943) do
     t.string "recommended_points"
     t.integer "dog_run", default: 2
     t.integer "bbq_area", default: 2
+    t.float "latitude"
+    t.float "longitude"
     t.index ["googlemaps_place_id"], name: "index_parks_on_googlemaps_place_id", unique: true
   end
 

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "app",
   "private": true,
   "dependencies": {
+    "@googlemaps/js-api-loader": "^1.16.6",
     "@hotwired/stimulus": "^3.2.2",
     "@hotwired/turbo-rails": "^8.0.4",
     "autoprefixer": "^10.4.19",

--- a/yarn.lock
+++ b/yarn.lock
@@ -122,6 +122,13 @@
   resolved "https://registry.yarnpkg.com/@esbuild/win32-x64/-/win32-x64-0.20.2.tgz#9c907b21e30a52db959ba4f80bb01a0cc403d5cc"
   integrity sha512-N49X4lJX27+l9jbLKSqZ6bKNjzQvHaT8IIFUy+YIqmXQdjYCToGWwOItDrfby14c78aDd5NHQl29xingXfCdLQ==
 
+"@googlemaps/js-api-loader@^1.16.6":
+  version "1.16.6"
+  resolved "https://registry.yarnpkg.com/@googlemaps/js-api-loader/-/js-api-loader-1.16.6.tgz#c89970c94b55796d51746c092f0e52953994a171"
+  integrity sha512-V8p5W9DbPQx74jWUmyYJOerhiB4C+MHekaO0ZRmc6lrOYrvY7+syLhzOWpp55kqSPeNb+qbC2h8i69aLIX6krQ==
+  dependencies:
+    fast-deep-equal "^3.1.3"
+
 "@hotwired/stimulus@^3.2.2":
   version "3.2.2"
   resolved "https://registry.yarnpkg.com/@hotwired/stimulus/-/stimulus-3.2.2.tgz#071aab59c600fed95b97939e605ff261a4251608"
@@ -443,6 +450,11 @@ escalade@^3.1.1:
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/escalade/-/escalade-3.1.2.tgz#54076e9ab29ea5bf3d8f1ed62acffbb88272df27"
   integrity sha512-ErCHMCae19vR8vQGe50xIsVomy19rg6gFu3+r3jkEO46suLMWBksvVyoGgQV+jOfl84ZSOSlmv6Gxa89PmTGmA==
+
+fast-deep-equal@^3.1.3:
+  version "3.1.3"
+  resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz#3a7d56b559d6cbc3eb512325244e619a65c6c525"
+  integrity sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==
 
 fast-glob@^3.3.0:
   version "3.3.2"
@@ -821,8 +833,16 @@ source-map-js@^1.2.0:
   resolved "https://registry.yarnpkg.com/source-map-js/-/source-map-js-1.2.0.tgz#16b809c162517b5b8c3e7dcd315a2a5c2612b2af"
   integrity sha512-itJW8lvSA0TXEphiRoawsCksnlf8SyvmFzIhltqAHluXd88pkCd+cXJVHTDwdCr0IzwptSm035IHQktUu1QUMg==
 
-"string-width-cjs@npm:string-width@^4.2.0", string-width@^4.1.0:
-  name string-width-cjs
+"string-width-cjs@npm:string-width@^4.2.0":
+  version "4.2.3"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
+  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
+  dependencies:
+    emoji-regex "^8.0.0"
+    is-fullwidth-code-point "^3.0.0"
+    strip-ansi "^6.0.1"
+
+string-width@^4.1.0:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -840,8 +860,14 @@ string-width@^5.0.1, string-width@^5.1.2:
     emoji-regex "^9.2.2"
     strip-ansi "^7.0.1"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
-  name strip-ansi-cjs
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
+  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
+  dependencies:
+    ansi-regex "^5.0.1"
+
+strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==


### PR DESCRIPTION
**公園検索画面の横に、GoogleのMaps Javascript APIを使用したマーカー付きマップを表示しました。**

- [x] 実装に伴い、Parksテーブルに新たに以下のカラムを追加しました。
　・latitude : float
　・longitude : float

- [x] 公園レポート新規投稿時に、緯度と経度をGoogle Place APIから取得するよう変更しました。
- [x] 公園検索ページでは、初期設定として以下の地図が表示されます。
　・現在地を取得できた場合は現在地を中心としたマップを表示する
　・現在地が取得できなかった場合は、皇居を中心としたマップを表示する
　・公園の検索を行うと、検索結果に当たる公園のみピンが刺さっているマップを表示する
　・ピンをクリックすると、公園の詳細ページと新規投稿ページに遷移するリンクを表示
　・新規投稿に遷移する際は、公園名と区の情報をフォームに渡した状態で遷移する

![b643072a00f0a3e80c3722bd171394a4](https://github.com/yamazaki-yuri/tokyopicnic/assets/151484437/dd1dbb4f-15bc-4012-bf73-ed59f27c9f18)
![0d9dfd05b876cce6b0ae9d906f164003](https://github.com/yamazaki-yuri/tokyopicnic/assets/151484437/78a55e27-c318-4a06-98ba-509ef2a7a1a1)


Closes #125