### PR TITLE
検索ページと投稿編集ページの修正

### DIFF
--- a/app/controllers/park_reports_controller.rb
+++ b/app/controllers/park_reports_controller.rb
@@ -42,7 +42,7 @@ class ParkReportsController < ApplicationController
       redirect_to @park_report
     else
       flash[:danger] = "編集に失敗しました"
-      render 'park_reports/show', status: :unprocessable_entity
+      render :show, status: :unprocessable_entity
     end
   end
 

--- a/app/javascript/controllers/focus_controller.js
+++ b/app/javascript/controllers/focus_controller.js
@@ -1,0 +1,13 @@
+import { Controller } from "@hotwired/stimulus"
+
+// Connects to data-controller="focus"
+export default class extends Controller {
+  static targets = ["edit", "title"]
+
+  connect() {
+    this.editTarget.addEventListener('click', this.focusTitle.bind(this))
+  }
+  focusTitle(){
+    this.titleTarget.focus();
+  }
+}

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -7,6 +7,9 @@ import { application } from "./application"
 import AutocompleteController from "./autocomplete_controller"
 application.register("autocomplete", AutocompleteController)
 
+import FocusController from "./focus_controller"
+application.register("focus", FocusController)
+
 import GoogleMap__ApplicationController from "./google_map/application_controller"
 application.register("google-map--application", GoogleMap__ApplicationController)
 

--- a/app/views/park_reports/_edit.html.erb
+++ b/app/views/park_reports/_edit.html.erb
@@ -5,7 +5,7 @@
   </div>
   <div class="mt-8 mb-8 flex flex-col px-5">
     <%= f.label :title, "公園をひとことで" %>
-    <%= f.text_field :title, placeholder: 'どんな公園？', class: "textarea textarea-primary" %>
+    <%= f.text_field :title, placeholder: 'どんな公園？', class: "textarea textarea-primary", data: { focus_target: "title" } %>
   </div>
   <div class="mt-8 mb-8 flex flex-col px-5">
     <%= f.label :comment, "思い出" %>

--- a/app/views/park_reports/new.html.erb
+++ b/app/views/park_reports/new.html.erb
@@ -13,32 +13,32 @@
           <div data-controller="autocomplete" data-autocomplete-min-length-value="2" data-autocomplete-url-value="/parks/autocomplete" role="combobox">
             <div class="mt-8 flex flex-col px-5">
               <%= f.label :name, "公園の名前" %>
-              <%= f.text_field :park_name, data: { autocomplete_target: 'input' }, placeholder: '公園の名前を入れてね', class: "input input-bordered input-primary bg-accent w-full max-w-xs" %>
+              <%= f.text_field :park_name, data: { autocomplete_target: 'input' }, placeholder: '公園の名前を入れてね', class: "input input-bordered input-primary bg-accent shadow w-full max-w-xs" %>
               <%= f.hidden_field :name, data: { autocomplete_target: 'hidden' } %>
               <%= f.hidden_field :park_id, data: { autocomplete_target: 'parkId' } %>
               <ul class="list-group mt-4 text-xs" data-autocomplete-target="results"></ul>
             </div>
             <div class="mt-8 flex flex-col w-2/3 px-5">
-              <%= f.collection_select :tokyo_ward_id, TokyoWard.all, :id, :name, { include_blank: "区を選択" }, { class: "select select-primary bg-accent max-w-xs", data: { autocomplete_target: 'ward' } } %>
+              <%= f.collection_select :tokyo_ward_id, TokyoWard.all, :id, :name, { include_blank: "区を選択" }, { class: "select select-primary bg-accent max-w-xs shadow", data: { autocomplete_target: 'ward' } } %>
             </div>
           </div>
           <div class="my-5 flex flex-col px-5">
             <%= f.label :date, "行った日" %>
-            <%= f.date_field :date, class: "block shadow rounded-md border border-gray-200 bg-accent outline-none px-3 py-2 mt-2 w-full" %>
+            <%= f.date_field :date, class: "block shadow rounded-md border bg-accent outline-none border-success px-3 py-2 mt-2 w-full" %>
           </div>
             <%= f.fields_for :report_images do |report_image| %>
               <div class="field mt-8 flex flex-col px-5">
                 <%= report_image.label :url, "写真" %>
-                <%= report_image.file_field :url, class: "file-input file-input-bordered file-input bg-accent w-full max-w-xs", style: "max-height: 40px;"%>
+                <%= report_image.file_field :url, class: "file-input file-input-bordered file-input shadow bg-accent border-success w-full max-w-xs", style: "max-height: 40px;"%>
               </div>
             <% end %>
           <div class="mt-8 mb-8 flex flex-col px-5">
             <%= f.label :title, "公園をひとことで(⚠︎必須)" %>
-            <%= f.text_field :title, placeholder: 'どんな公園だった？', class: "textarea textarea-primary bg-accent" %>
+            <%= f.text_field :title, placeholder: 'どんな公園だった？', class: "textarea textarea-primary bg-accent shadow" %>
           </div>
           <div class="mt-8 mb-8 flex flex-col px-5">
             <%= f.label :comment, "思い出" %>
-            <%= f.text_area :comment, placeholder: '自由に記入して思い出を残そう', class: "textarea textarea-primary bg-accent" %>
+            <%= f.text_area :comment, placeholder: '自由に記入して思い出を残そう', class: "textarea textarea-primary bg-accent shadow" %>
           </div>
           <div class="my-5 flex flex-col px-5">
             <button class="btn btn-primary">

--- a/app/views/park_reports/show.html.erb
+++ b/app/views/park_reports/show.html.erb
@@ -18,17 +18,19 @@
         </h2>
         <div class="flex justify-between border-b-2 border-slate-200 pb-1 text-park">
           <p class="pl-8"><%= @park_report.date %></p>
-          <% if user_signed_in? && current_user.own?(@park_report) %>
-            <button class="pr-5" onclick="report_edit.showModal()"><i class="fa-solid fa-pen"></i>編集</button>
-          <% end %>
-          <dialog id="report_edit" class="modal">
-            <div class="modal-box">
-              <%= render 'edit' %>
-            </div>
-            <form method="dialog" class="modal-backdrop">
-              <button>close</button>
-            </form>
-          </dialog>
+          <div data-controller="focus">
+            <% if user_signed_in? && current_user.own?(@park_report) %>
+              <button class="pr-5" data-focus-target="edit" onclick="report_edit.showModal()"><i class="fa-solid fa-pen"></i>編集</button>
+            <% end %>
+            <dialog id="report_edit" class="modal">
+              <div class="modal-box">
+                <%= render 'edit' %>
+              </div>
+              <form method="dialog" class="modal-backdrop">
+                <button>close</button>
+              </form>
+            </dialog>
+          </div>
           <% if user_signed_in? && current_user.own?(@park_report) %>
             <div class="pr-5">
               <%= link_to park_report_path(@park_report), data: { turbo_method: :delete, turbo_confirm: '投稿を削除しますか？画像も全て削除されます。'} do %>

--- a/app/views/parks/_search_form.html.erb
+++ b/app/views/parks/_search_form.html.erb
@@ -55,7 +55,7 @@
         </div>
       </div>
       <div class="flex justify-center mt-3">
-        <div class="btn btn-sm btn-secondary mt-3">
+        <div class="btn btn-sm btn-secondary border-park mt-3">
         <i class="fa-solid fa-magnifying-glass">
           <%= f.submit "検索する" %>
         </i>

--- a/app/views/parks/index.html.erb
+++ b/app/views/parks/index.html.erb
@@ -9,9 +9,14 @@
       <%= render 'search_form' %>
     </div>
     <div class="md:w-1/2 xl:w-2/3 pb-5">
-      <div data-controller="google-map--index">
+      <gmp-map map-id="parkmap" data-controller="google-map--index">
         <div data-google-map--index-target="map" data-json="<%= @parks_json %>" style="height:55vh;max-width:800px;"></div>
-      </div>
+        <div class="btn btn-sm btn-secondary border-park mt-3">
+        <i class="fa-solid fa-magnifying-glass">
+        <button data-google-map--index-target="user_location">現在地周辺を表示する</button>
+        </i>
+        </div>
+      </gmp-map>
     </div>
   </div>
   <% if params[:q].present? %>

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -22,8 +22,9 @@
         </figure>
         <div class="card-body bg-white rounded-lg">
             <p><%= park_report.date %></p>
-          <%= link_to "#{park_report.park.name}", park_path(park_report.park), class: "card-title pb-2 border-b-2 border-slate-200 hover:bg-slate-200 rounded-lg px-4 py-2" %>
-          <%= link_to "#{park_report.title}", park_report_path(park_report), class: "pl-5 text-park font-bold hover:bg-slate-200 rounded-lg px-4 py-2" %>
+          <%= link_to "#{park_report.park.name}", park_path(park_report.park), class: "card-title hover:bg-slate-200 rounded-lg px-4 py-1" %>
+          <p class="border-b-2 border-slate-200"></p>
+          <%= link_to "#{park_report.title}", park_report_path(park_report), class: "pl-5 text-park font-bold hover:bg-slate-200 rounded-lg px-4 py-1" %>
         </div>
       </div>
     <% end %>
@@ -49,7 +50,7 @@
         </div>
       </figure>
       <div class="card-body bg-white rounded-lg">
-        <p class="card-title pb-2 border-b-2 border-slate-200"><%= bookmark_park.name %></p>
+        <p class="card-title border-b-2 border-slate-200"><%= bookmark_park.name %></p>
       </div>
     <% end %>
   <% end %>


### PR DESCRIPTION
- [x] 検索ページを開いた際の初期マップを変更しました
・東京２３区の公園しかないので、23区にいるユーザー以外は現在地取得がデフォルトなのは使い勝手が悪いため。
・初期設定では皇居を中心としたマップを表示する設定に変更し、`現在地周辺を表示する`というボタンを押した時に、現在地を中心としたマップが表示されるよう変更しました。

- [x] 投稿詳細から編集マークを押した際に、日付にフォーカスが当たる状態を修正しました
→スマートフォンで見ると、編集ボタンを押した時に画面全体にカレンダーが表示される仕様になってしまうため。
・stimulusを使用したfocus_controller.jsを作成し、編集ボタンが押された時にフォーカスが公園のtitle部分に当たるように修正しました。

![a8151685d1ffaaeeb2f4c48a98c1ca79](https://github.com/yamazaki-yuri/tokyopicnic/assets/151484437/35bd7406-de90-41a2-950f-53ebed15f941)

