### PR TITLE
画像アップロード中のローディング画面の設定

### DIFF
--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -19,5 +19,8 @@ application.register("google-map--index", GoogleMap__IndexController)
 import HelloController from "./hello_controller"
 application.register("hello", HelloController)
 
+import LoadingController from "./loading_controller"
+application.register("loading", LoadingController)
+
 import SliderController from "./slider_controller"
 application.register("slider", SliderController)

--- a/app/javascript/controllers/loading_controller.js
+++ b/app/javascript/controllers/loading_controller.js
@@ -1,0 +1,27 @@
+import { Controller } from "@hotwired/stimulus"
+
+// Connects to data-controller="loading"
+export default class extends Controller {
+  static targets = ["modal", "submit"];
+
+  connect() {
+    if (this.hasSubmitTarget) {
+      this.submitTarget.addEventListener('click',this.show.bind(this));
+    }
+
+    document.addEventListener("turbolinks:load", () => {
+      const flashSuccess = document.getElementById("flash-message");
+      if (flashSuccess) {
+        this.hide();
+      }
+    });
+  }
+
+  show() {
+    this.modalTarget.showModal();
+  }
+
+  hide() {
+    this.modalTarget.close();
+  }
+}

--- a/app/views/park_images/_form.html.erb
+++ b/app/views/park_images/_form.html.erb
@@ -1,9 +1,12 @@
-<%= form_with(model: @park_image, remote: true, local: true, url: park_images_path, class: "justify-between item-center") do |f| %>
-  <%= f.hidden_field :park_id, value: @park.id %>
-    <div class="field px-2">
-  <%= f.file_field :url, class: "file-input file-input-bordered file-input-accent w-full max-w-xs" %>
-  </div>
-  <div class="btn btn-ghost rounded-btn hover:bg-slate-200 text-park mt-5 w-full">
-    <%= f.submit t('helpers.submit.submit') %>
-  </div>
-<% end %>
+<div data-controller="loading">
+  <%= render 'shared/loading' %>
+  <%= form_with(model: @park_image, remote: true, local: true, url: park_images_path, class: "justify-between item-center") do |f| %>
+    <%= f.hidden_field :park_id, value: @park.id %>
+      <div class="field px-2">
+    <%= f.file_field :url, class: "file-input file-input-bordered file-input-accent w-full max-w-xs" %>
+    </div>
+    <div class="btn btn-ghost rounded-btn hover:bg-slate-200 text-park mt-5 w-full" data-loading-target="submit">
+      <%= f.submit t('helpers.submit.submit') %>
+    </div>
+  <% end %>
+</div>

--- a/app/views/park_reports/new.html.erb
+++ b/app/views/park_reports/new.html.erb
@@ -1,5 +1,6 @@
 <% content_for(:title, t('.title')) %>
-<div class="flex-grow container mx-auto px-6 py-5">
+<div class="flex-grow container mx-auto px-6 py-5" data-controller="loading">
+  <%= render 'shared/loading' %>
   <div class="flex justify-center items-center">
     <div class="text-2xl md:text-3xl lg:text-4xl text-park text-center font-bold pb-5 px-8 border-b-2 border-park">
     新規投稿
@@ -41,7 +42,7 @@
             <%= f.text_area :comment, placeholder: '自由に記入して思い出を残そう', class: "textarea textarea-primary bg-accent shadow" %>
           </div>
           <div class="my-5 flex flex-col px-5">
-            <button class="btn btn-primary">
+            <button class="btn btn-primary" data-loading-target="submit">
               <%= f.submit t('helpers.submit.submit') %>
             </button>
           </div>

--- a/app/views/report_images/_form.html.erb
+++ b/app/views/report_images/_form.html.erb
@@ -1,9 +1,12 @@
-<%= form_with(model: @report_image, remote: true, local: true, url: report_images_path, class: "justify-between item-center") do |f| %>
-  <%= f.hidden_field :park_report_id, value: @park_report.id %>
-  <div class="field px-2">
-    <%= f.file_field :url, class: "file-input file-input-bordered file-input-accent w-full max-w-xs" %>
-  </div>
-  <div class="btn btn-ghost rounded-btn hover:bg-slate-200 text-park mt-5 w-full">
-    <%= f.submit t('helpers.submit.submit') %>
-  </div>
-<% end %>
+<div data-controller="loading">
+  <%= render 'shared/loading' %>
+  <%= form_with(model: @report_image, remote: true, local: true, url: report_images_path, class: "justify-between item-center") do |f| %>
+    <%= f.hidden_field :park_report_id, value: @park_report.id %>
+    <div class="field px-2">
+      <%= f.file_field :url, class: "file-input file-input-bordered file-input-accent w-full max-w-xs" %>
+    </div>
+    <div class="btn btn-ghost rounded-btn hover:bg-slate-200 text-park mt-5 w-full" data-loading-target="submit">
+      <%= f.submit t('helpers.submit.submit') %>
+    </div>
+  <% end %>
+</div>

--- a/app/views/shared/_flash_message.html.erb
+++ b/app/views/shared/_flash_message.html.erb
@@ -1,6 +1,6 @@
 <div class="px-3">
   <% flash.each do |message_type, message| %>
-    <div class="rounded-b text-park font-bold px-4 py-5" role="alert">
+    <div id="flash-message" class="rounded-b text-park font-bold px-4 py-5" role="alert">
       <%= message %>
     </div>
   <% end %>

--- a/app/views/shared/_loading.html.erb
+++ b/app/views/shared/_loading.html.erb
@@ -1,0 +1,8 @@
+<dialog id="loading-modal" class="modal" data-loading-target="modal">
+  <div class="modal-box flex justify-center items-center">
+    <img src="<%= asset_path('loading_sandwitch.gif') %>" alt="Proccesing GIF">
+  </div>
+  <form method="dialog" class="modal-backdrop">
+    <button>close</button>
+  </form>
+</dialog>

--- a/config/locales/activerecord.ja.yml
+++ b/config/locales/activerecord.ja.yml
@@ -19,7 +19,7 @@ ja:
         catchphrase: キャッチフレーズ
         recommended_points: おすすめの理由
         dog_run: ドッグラン
-        bbq_area: BQQ場
+        bbq_area: BBQ場
       park_report:
         park: 公園の名前
         date: 行った日


### PR DESCRIPTION
下記のユーザーのアクション実行時にロード画面を設定しました。
・公園新規投稿時
・公園画像追加時
・公園日記の画像追加時

処理の流れは以下の通りです。
・ユーザーのsubmitボタン実行時にloading_controller.jsのshow()が発火しモーダルを表示する
・flash_messageが画面に表示された際にloading_controller.jsのhide()が発火しモーダルが閉じる

![4174d01c52ecff310a8c140304ecc9fd](https://github.com/yamazaki-yuri/tokyopicnic/assets/151484437/920c6b47-5c2d-4a02-b985-23b930f3af41)

Closes #133 
