### PR TITLE
googleから写真を取得

### DIFF
--- a/app/controllers/park_reports_controller.rb
+++ b/app/controllers/park_reports_controller.rb
@@ -31,6 +31,7 @@ class ParkReportsController < ApplicationController
 
     if @park
       @tokyo_ward = @park.tokyo_wards.first
+      fetch_and_add_park_image(@park)
     else
       receive_tokyo_ward
     end
@@ -131,5 +132,34 @@ class ParkReportsController < ApplicationController
   
     @park = Park.create(name: @park_name, googlemaps_place_id: place_id, website_url: website, latitude: park_lat, longitude: park_lng)
     @park.tokyo_wards << @tokyo_ward
+
+    add_image_to_park(google_places_service, park_info, @park)
+  end
+
+  def fetch_and_add_park_image(park)
+    google_places_service = GooglePlacesService.new
+    response = google_places_service.search("#{park.latitude},#{park.longitude}", park.name)
+
+    park_info = response['results'].first
+    return if park_info.nil?
+
+    add_image_to_park(google_places_service, park_info, park)
+  end
+
+  def add_image_to_park(google_places_service, park_info, park)
+    return unless park_info['photos'].present?
+
+    photo_reference = park_info['photos'].first['photo_reference']
+    image_url = google_places_service.get_photo_url(photo_reference)
+
+    service = ImageDownloadService.new(image_url)
+    temp_file = service.download_and_process
+
+    if temp_file
+      park_image = park.park_images.create(url: File.open(temp_file.path))
+    end
+  ensure
+    temp_file.close if temp_file
+    temp_file.unlink if temp_file
   end
 end

--- a/app/servise/google_places_service.rb
+++ b/app/servise/google_places_service.rb
@@ -32,4 +32,17 @@ class GooglePlacesService
     }
     self.class.get("/details/json", options)
   end
+
+  def get_photo_url(photo_reference)
+    options = {
+      query: {
+        maxwidth: 600,
+        maxheight: 500,
+        photoreference: photo_reference,
+        key: @api_key
+      }
+    }
+    response = self.class.get("/photo", options)
+    response.request.last_uri.to_s if response.success?
+  end
 end

--- a/app/servise/image_download_service.rb
+++ b/app/servise/image_download_service.rb
@@ -1,0 +1,21 @@
+require 'open-uri'
+require 'mini_magick'
+
+class ImageDownloadService
+  def initialize(url)
+    @url = url
+  end
+
+  def download_and_process
+    downloaded_image = URI.open(@url)
+    image = MiniMagick::Image.read(downloaded_image)
+    image.format "webp"
+
+    temp_file = Tempfile.new(['park_image', '.webp'])
+    image.write(temp_file.path)
+    temp_file
+  rescue => e
+    Rails.logger.error "Error downloading or processing image: #{e.message}"
+    nil
+  end
+end

--- a/app/views/parks/index.html.erb
+++ b/app/views/parks/index.html.erb
@@ -27,7 +27,7 @@
     <% @parks.each do |park| %>
       <%= link_to park_path(park), data: { turbo: false }, class: "card bg-base-100 shadow-xl flex flex-col md:gap-x-10" do %>
         <figure>
-        <div style="max-height: 230px; width: 100%; object-fit: cover;">
+        <div style="max-height: 180px; width: 100%; object-fit: cover;">
           <% if park.park_images.present? && park.park_images.first.url.present? %>
             <%= image_tag park.park_images.first.url.url %>
           <% else %>


### PR DESCRIPTION
現状は、新規作成時にparksテーブルに情報がない公園の投稿の際に、googleAPIから写真情報の取得はしていませんでした。
・公園情報取得の際に、googleから写真の取得も行うように変更しました。